### PR TITLE
chore: update release-please workflow token for Noko releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           release-type: node
           package-name: noko
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NOKO_FOR_RAYCAST_RELEASE_TOKEN }}
 
   build-and-test:
     needs: release-please


### PR DESCRIPTION
Update releaser token name, since `GITHUB_*` tokens are not allowed to be changed in the Settings.