### PR TITLE
feat(ui): improve navigation consistency

### DIFF
--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -105,10 +105,10 @@ export const EntryItem = memo<EntryItemProps>(
             />
             {onCancel && (
               <Action
-                title="Cancel"
+                title="Back"
                 icon={Icon.ArrowLeft}
                 onAction={onCancel}
-                shortcut={{ modifiers: ["shift", "cmd"], key: "enter" }}
+                shortcut={{ modifiers: ["cmd"], key: "[" }}
               />
             )}
           </ActionPanel>

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -1,4 +1,11 @@
-import { Form, ActionPanel, Action, showToast, Toast } from "@raycast/api";
+import {
+  Form,
+  ActionPanel,
+  Action,
+  showToast,
+  Toast,
+  Icon,
+} from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
 import { EntryFormData, ProjectType } from "../types";
 import { useProjects, useTags, useTimer } from "../hooks/useApiData";
@@ -96,9 +103,10 @@ export const AddEntryView = ({
           <Action.SubmitForm onSubmit={handleSubmit} />
           {onCancel && (
             <Action
-              title="Cancel"
+              title="Back"
+              icon={Icon.ArrowLeft}
               onAction={onCancel}
-              shortcut={{ modifiers: ["shift", "cmd"], key: "enter" }}
+              shortcut={{ modifiers: ["cmd"], key: "[" }}
             />
           )}
         </ActionPanel>

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -61,7 +61,7 @@ export const EntriesView = ({ onCancel }: EntriesViewProps) => {
         <ActionPanel>
           {onCancel && (
             <Action
-              title="Cancel"
+              title="Back"
               icon={Icon.ArrowLeft}
               onAction={onCancel}
               shortcut={{ modifiers: ["cmd"], key: "[" }}


### PR DESCRIPTION
## 🎯 Changes

This PR improves the navigation consistency across the application by standardizing button labels and keyboard shortcuts.

### ✨ What's Changed

- **Button Labels**: Changed 'Cancel' button text to 'Back' across all views for better UX consistency
- **Keyboard Shortcuts**: Updated shortcut from `Shift+Cmd+Enter` to `Cmd+[` for more intuitive navigation
- **Components Updated**: 
  - `EntryItem` component
  - `AddEntryView` component  
  - `EntriesView` component

### 🎨 UI/UX Improvements

- More intuitive 'Back' label instead of 'Cancel' for navigation actions
- Standard keyboard shortcut `Cmd+[` follows common macOS conventions
- Consistent navigation experience across all views

### 🧪 Testing

- [x] Verified button text changes display correctly
- [x] Confirmed keyboard shortcuts work as expected
- [x] Tested navigation flow across all affected views

### 📝 Type of Change

- [x] UI/UX improvement
- [x] Non-breaking change
- [x] Follows conventional commits format