### PR TITLE
feat(entries): add entry creation action to entries view

### DIFF
--- a/src/timers.tsx
+++ b/src/timers.tsx
@@ -10,6 +10,7 @@ export default function Command() {
   const [project, setProject] = useState<ProjectType | null>(null);
 
   const handleAddEntry = () => {
+    setProject(null);
     setCurrentView("add-entry");
   };
 
@@ -52,7 +53,10 @@ export default function Command() {
   if (currentView === "entries") {
     return (
       <ErrorBoundary>
-        <EntriesView onCancel={handleBackToTimers} />
+        <EntriesView
+          onCancel={handleBackToTimers}
+          onAddEntry={handleAddEntry}
+        />
       </ErrorBoundary>
     );
   }

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -7,9 +7,10 @@ import { UI_MESSAGES } from "../constants";
 
 interface EntriesViewProps {
   onCancel?: () => void;
+  onAddEntry?: () => void;
 }
 
-export const EntriesView = ({ onCancel }: EntriesViewProps) => {
+export const EntriesView = ({ onCancel, onAddEntry }: EntriesViewProps) => {
   const { isLoading, filter, filteredEntries, setFilter, error } = useEntries();
   const { isShowingDetail, toggleDetail } = useDetailToggle(false);
 
@@ -59,6 +60,14 @@ export const EntriesView = ({ onCancel }: EntriesViewProps) => {
       isShowingDetail={isShowingDetail}
       actions={
         <ActionPanel>
+          {onAddEntry && (
+            <Action
+              title="Add Entry"
+              icon={Icon.Plus}
+              onAction={onAddEntry}
+              shortcut={{ modifiers: ["cmd"], key: "n" }}
+            />
+          )}
           {onCancel && (
             <Action
               title="Back"


### PR DESCRIPTION
## 🚀 Feature: Add Entry Creation Action to Entries View

This PR enhances the entries view by adding the ability to create new entries directly from the entries list, improving the user workflow.

### ✨ Changes Made

- **Added  prop to  component** - Allows parent components to pass a callback for entry creation
- **Added 'Add Entry' action to EntriesView action panel** - Users can now create entries with Cmd+N shortcut
- **Reset project state when navigating to add entry** - Ensures clean state when creating entries from the main view
- **Improved user experience** - Streamlined workflow for creating entries from any view

### 🎯 Benefits

- **Better UX**: Users can create entries without navigating back to the main timers view
- **Keyboard shortcut**: Cmd+N provides quick access to entry creation
- **Consistent state management**: Proper project state reset prevents stale data
- **Enhanced workflow**: More intuitive navigation between views

### 🧪 Testing

- [x] Add Entry action appears in EntriesView action panel
- [x] Cmd+N shortcut works correctly
- [x] Navigation to add entry view works properly
- [x] Project state is properly reset
- [x] No breaking changes to existing functionality

### 📝 Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### 🔗 Related Issues

Closes any related issues or enhances the user experience for entry management.

---
*This PR follows conventional commit standards and is ready for review.*