### PR TITLE
feat: add configurable sound interval preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,79 @@
           "value": "Australia/Sydney"
         }
       ]
+    },
+    {
+      "name": "soundNotification",
+      "type": "dropdown",
+      "required": false,
+      "title": "Sound Notification",
+      "description": "Choose the sound to play at regular intervals when timer is running. Use 'Test Sound' command to preview.",
+      "default": "glass",
+      "data": [
+        {
+          "title": "None (No Sound)",
+          "value": "none"
+        },
+        {
+          "title": "Glass (Smooth)",
+          "value": "glass"
+        },
+        {
+          "title": "Ping (Gentle)",
+          "value": "ping"
+        },
+        {
+          "title": "Pop (Soft)",
+          "value": "pop"
+        },
+        {
+          "title": "Sosumi (Classic)",
+          "value": "sosumi"
+        },
+        {
+          "title": "Tink (Light)",
+          "value": "tink"
+        }
+      ]
+    },
+    {
+      "name": "soundVolume",
+      "type": "textfield",
+      "required": false,
+      "title": "Sound Volume",
+      "description": "Volume level for sound notifications (0.0 to 1.0). Leave empty for system default.",
+      "placeholder": "0.5",
+      "default": ""
+    },
+    {
+      "name": "soundInterval",
+      "type": "dropdown",
+      "required": false,
+      "title": "Sound Interval",
+      "description": "How often to play sound notifications when timer is running. Default is 15 minutes.",
+      "default": "15",
+      "data": [
+        {
+          "title": "1 minute",
+          "value": "1"
+        },
+        {
+          "title": "5 minutes",
+          "value": "5"
+        },
+        {
+          "title": "15 minutes",
+          "value": "15"
+        },
+        {
+          "title": "30 minutes",
+          "value": "30"
+        },
+        {
+          "title": "1 hour",
+          "value": "60"
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/src/__tests__/useElapsedTime.test.ts
+++ b/src/__tests__/useElapsedTime.test.ts
@@ -74,6 +74,7 @@ describe("useElapsedTime", () => {
     mockGetPreferenceValues.mockReturnValue({
       soundNotification: "glass",
       soundVolume: "0.5",
+      soundInterval: "15",
     });
   });
 
@@ -390,6 +391,7 @@ describe("useElapsedTime", () => {
     mockGetPreferenceValues.mockReturnValue({
       soundNotification: "hero",
       soundVolume: "0.8",
+      soundInterval: "15",
     });
 
     // Mock elapsed time to be exactly 15 minutes
@@ -413,6 +415,7 @@ describe("useElapsedTime", () => {
     mockGetPreferenceValues.mockReturnValue({
       soundNotification: "none",
       soundVolume: "0.5",
+      soundInterval: "15",
     });
 
     // Mock elapsed time to be exactly 15 minutes
@@ -427,8 +430,7 @@ describe("useElapsedTime", () => {
     });
 
     // Should not play any sound
-    expect(mockPlaySystemSound).toHaveBeenCalledTimes(1);
-    expect(mockPlaySystemSound).toHaveBeenCalledWith("none", "0.5");
+    expect(mockPlaySystemSound).not.toHaveBeenCalled();
   });
 
   it("should use default sound when no preference is set", () => {
@@ -446,7 +448,7 @@ describe("useElapsedTime", () => {
       jest.advanceTimersByTime(1000);
     });
 
-    // Should use default glass sound
+    // Should use default glass sound with default 15-minute interval
     expect(mockPlaySystemSound).toHaveBeenCalledTimes(1);
     expect(mockPlaySystemSound).toHaveBeenCalledWith("glass", undefined);
   });
@@ -461,6 +463,7 @@ describe("useElapsedTime", () => {
       mockGetPreferenceValues.mockReturnValue({
         soundNotification: soundType,
         soundVolume: "0.3",
+        soundInterval: "15",
       });
 
       // Mock elapsed time to be exactly 15 minutes

--- a/src/hooks/useElapsedTime.ts
+++ b/src/hooks/useElapsedTime.ts
@@ -54,19 +54,22 @@ const useElapsedTime = (timer: TimerType) => {
 
         // Get user preferences for sound
         const preferences = getPreferenceValues();
-        const soundInterval = parseInt(preferences.soundInterval, 10);
-        const timeIncrement = soundInterval;
+        const soundInterval = parseInt(preferences.soundInterval, 10) || 15; // Default to 15 minutes
 
         // Play sound every time increment (e.g., every 15 minutes)
         if (
+          Number.isFinite(soundInterval) &&
           currentElapsedMinutes > 0 &&
-          currentElapsedMinutes % timeIncrement === 0 &&
+          currentElapsedMinutes % soundInterval === 0 &&
           currentElapsedMinutes !== lastSoundNotificationRef.current
         ) {
           const soundType = preferences.soundNotification || "glass";
           const volume = preferences.soundVolume;
 
-          playSystemSound(soundType, volume);
+          // Only play sound if it's not set to 'none'
+          if (soundType !== "none") {
+            playSystemSound(soundType, volume);
+          }
           lastSoundNotificationRef.current = currentElapsedMinutes;
         }
       }, 1000);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@
 interface IPreferences {
   personalAccessToken: string;
   timezone?: string;
+  soundNotification?: string;
+  soundVolume?: string;
+  soundInterval?: string;
 }
 
 // ============================================================================

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -251,6 +251,60 @@ const getEntriesSummary = (entries: EntryType[]): EntriesSummaryType => {
 };
 
 // ============================================================================
+// SOUND UTILITIES
+// ============================================================================
+
+// Sound file mappings for macOS system sounds
+const SOUND_FILES: Record<string, string> = {
+  glass: "/System/Library/Sounds/Glass.aiff",
+  ping: "/System/Library/Sounds/Ping.aiff",
+  pop: "/System/Library/Sounds/Pop.aiff",
+  sosumi: "/System/Library/Sounds/Sosumi.aiff",
+  tink: "/System/Library/Sounds/Tink.aiff",
+};
+
+const playSystemSound = (
+  soundType: string = "glass",
+  volume?: string,
+): void => {
+  try {
+    // Don't play sound if user selected "none"
+    if (soundType === "none") {
+      return;
+    }
+
+    // Get the sound file path
+    const soundFile = SOUND_FILES[soundType];
+    if (!soundFile) {
+      console.log(`Unknown sound type: ${soundType}`);
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { exec } = require("child_process");
+
+    // Build the afplay command with optional volume
+    let command = `afplay "${soundFile}"`;
+    if (volume && volume.trim() !== "") {
+      const volumeNum = parseFloat(volume);
+      if (!isNaN(volumeNum) && volumeNum >= 0 && volumeNum <= 1) {
+        command += ` -v ${volumeNum}`;
+      }
+    }
+
+    exec(command, (error: Error | null) => {
+      if (error) {
+        // Fallback to a simple beep if the sound file is not available
+        exec('echo -e "\\a"', () => {});
+      }
+    });
+  } catch (error) {
+    // Silent fail - don't break the timer functionality if sound fails
+    console.log("Sound notification failed:", error);
+  }
+};
+
+// ============================================================================
 // EXPORTS
 // ============================================================================
 
@@ -278,4 +332,6 @@ export {
   // Entry summary utilities
   calculateEntrySummary,
   getEntriesSummary,
+  // Sound utilities
+  playSystemSound,
 };


### PR DESCRIPTION
Add configurable sound notification intervals for timer reminders. Users can now choose from 1, 5, 15, 30, or 60-minute intervals via a dropdown preference. Also simplified sound options to 5 most common system sounds.