### PR TITLE
feat(timer): add reset timer action

### DIFF
--- a/src/components/TimerItem.tsx
+++ b/src/components/TimerItem.tsx
@@ -18,9 +18,10 @@ const TimerItem = memo<TimerItemProps>(
 
     const elapsedTime = useElapsedTime(timer);
 
-    const { startTimer, pauseTimer, discardTimer } = useTimerActions({
-      onSuccess: onTimerChange,
-    });
+    const { startTimer, pauseTimer, discardTimer, resetTimer } =
+      useTimerActions({
+        onSuccess: onTimerChange,
+      });
 
     const subtitle = useMemo(() => {
       const state =
@@ -41,6 +42,12 @@ const TimerItem = memo<TimerItemProps>(
               title="Log Timer"
               icon={Icon.Stop}
               onAction={() => onLogTimer(currentProject)}
+            />
+            <Action
+              title="Reset Timer"
+              icon={Icon.ArrowClockwise}
+              onAction={() => resetTimer(currentProject)}
+              style={Action.Style.Destructive}
             />
             <Action
               title="Discard Timer"
@@ -66,6 +73,12 @@ const TimerItem = memo<TimerItemProps>(
             onAction={() => onLogTimer(currentProject)}
           />
           <Action
+            title="Reset Timer"
+            icon={Icon.ArrowClockwise}
+            onAction={() => resetTimer(currentProject)}
+            style={Action.Style.Destructive}
+          />
+          <Action
             title="Discard Timer"
             icon={Icon.Trash}
             onAction={() => discardTimer(currentProject)}
@@ -79,6 +92,7 @@ const TimerItem = memo<TimerItemProps>(
       startTimer,
       pauseTimer,
       discardTimer,
+      resetTimer,
       onLogTimer,
     ]);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const TOAST_MESSAGES = {
     TIMER_PAUSED: "Timer Paused",
     TIMER_DISCARDED: "Timer Discarded",
     TIMER_LOGGED: "Timer Logged",
+    TIMER_RESET: "Timer Reset",
   },
   ERROR: {
     FAILED_TO_ADD_ENTRY: "Failed to Add Entry",
@@ -28,6 +29,7 @@ export const TOAST_MESSAGES = {
     FAILED_TO_PAUSE_TIMER: "Failed to Pause Timer",
     FAILED_TO_DISCARD_TIMER: "Failed to Discard Timer",
     FAILED_TO_LOG_TIMER: "Failed to Log Timer",
+    FAILED_TO_RESET_TIMER: "Failed to Reset Timer",
     INVALID_INPUT: "Invalid Input",
     NETWORK_ERROR: "Network error",
     UNKNOWN_ERROR: "Unknown error",

--- a/src/hooks/useTimerActions.ts
+++ b/src/hooks/useTimerActions.ts
@@ -50,48 +50,58 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
     [onSuccess, onError],
   );
 
+  const apiStartTimer = useCallback(async (project: ProjectType) => {
+    return await apiClient.put(`/projects/${project.id}/timer/start`);
+  }, []);
+
+  const apiPauseTimer = useCallback(async (project: ProjectType) => {
+    return await apiClient.put(`/projects/${project.id}/timer/pause`);
+  }, []);
+
+  const apiDiscardTimer = useCallback(async (project: ProjectType) => {
+    return await apiClient.delete(`/projects/${project.id}/timer`);
+  }, []);
+
   const startTimer = useCallback(
     async (project: ProjectType) => {
       await handleApiCall(
-        () => apiClient.put(`/projects/${project.id}/timer/start`),
+        () => apiStartTimer(project),
         `Started timer for ${project.name}`,
         TOAST_MESSAGES.ERROR.FAILED_TO_START_TIMER,
         TOAST_MESSAGES.SUCCESS.TIMER_STARTED,
       );
     },
-    [handleApiCall],
+    [handleApiCall, apiStartTimer],
   );
 
   const pauseTimer = useCallback(
     async (project: ProjectType) => {
       await handleApiCall(
-        () => apiClient.put(`/projects/${project.id}/timer/pause`),
+        () => apiPauseTimer(project),
         `Paused timer for ${project.name}`,
         TOAST_MESSAGES.ERROR.FAILED_TO_PAUSE_TIMER,
         TOAST_MESSAGES.SUCCESS.TIMER_PAUSED,
       );
     },
-    [handleApiCall],
+    [handleApiCall, apiPauseTimer],
   );
 
   const discardTimer = useCallback(
     async (project: ProjectType) => {
       await handleApiCall(
-        () => apiClient.delete(`/projects/${project.id}/timer`),
+        () => apiDiscardTimer(project),
         `Timer discarded for ${project.name} (time not saved)`,
         TOAST_MESSAGES.ERROR.FAILED_TO_DISCARD_TIMER,
         TOAST_MESSAGES.SUCCESS.TIMER_DISCARDED,
       );
     },
-    [handleApiCall],
+    [handleApiCall, apiDiscardTimer],
   );
 
   const resetTimer = useCallback(
     async (project: ProjectType) => {
       try {
-        const discardResult = await apiClient.delete(
-          `/projects/${project.id}/timer`,
-        );
+        const discardResult = await apiDiscardTimer(project);
 
         if (!discardResult.success) {
           const errorMessage =
@@ -104,9 +114,7 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
           return;
         }
 
-        const startResult = await apiClient.put(
-          `/projects/${project.id}/timer/start`,
-        );
+        const startResult = await apiStartTimer(project);
 
         if (!startResult.success) {
           const errorMessage =
@@ -136,7 +144,7 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
         onError?.(errorMessage);
       }
     },
-    [onSuccess, onError],
+    [apiDiscardTimer, apiStartTimer, onSuccess, onError],
   );
 
   const logTimer = useCallback(

--- a/src/hooks/useTimerActions.ts
+++ b/src/hooks/useTimerActions.ts
@@ -86,6 +86,59 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
     [handleApiCall],
   );
 
+  const resetTimer = useCallback(
+    async (project: ProjectType) => {
+      try {
+        const discardResult = await apiClient.delete(
+          `/projects/${project.id}/timer`,
+        );
+
+        if (!discardResult.success) {
+          const errorMessage =
+            discardResult.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+          showErrorToast(
+            TOAST_MESSAGES.ERROR.FAILED_TO_RESET_TIMER,
+            errorMessage,
+          );
+          onError?.(errorMessage);
+          return;
+        }
+
+        const startResult = await apiClient.put(
+          `/projects/${project.id}/timer/start`,
+        );
+
+        if (!startResult.success) {
+          const errorMessage =
+            startResult.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+          showErrorToast(
+            TOAST_MESSAGES.ERROR.FAILED_TO_RESET_TIMER,
+            errorMessage,
+          );
+          onError?.(errorMessage);
+          return;
+        }
+
+        showSuccessToast(
+          TOAST_MESSAGES.SUCCESS.TIMER_RESET,
+          `Timer reset for ${project.name}`,
+        );
+        onSuccess?.();
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+        showErrorToast(
+          TOAST_MESSAGES.ERROR.FAILED_TO_RESET_TIMER,
+          errorMessage,
+        );
+        onError?.(errorMessage);
+      }
+    },
+    [onSuccess, onError],
+  );
+
   const logTimer = useCallback(
     async (projectId: string, entryData: EntryFormData) => {
       const payload = {
@@ -111,6 +164,7 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
     startTimer,
     pauseTimer,
     discardTimer,
+    resetTimer,
     logTimer,
   };
 };


### PR DESCRIPTION
## Summary

This PR adds a "Reset Timer" action to the Noko Raycast extension, allowing users to discard their current timer without saving and immediately start a fresh timer on the same project.

## Changes

### ✨ Features
- **Reset Timer Action**: New action to discard current timer and start fresh on same project
- **Internal API Helpers**: Extracted `apiStartTimer`, `apiPauseTimer`, and `apiDiscardTimer` functions to reduce code duplication
- **Reusable Timer Actions**: Reset timer now reuses existing API call logic for better maintainability

### 🎨 UI/UX
- **Destructive Styling**: Reset action uses destructive style since it discards current time
- **Clockwise Arrow Icon**: Uses `Icon.ArrowClockwise` to indicate reset operation
- **No Keyboard Shortcut**: No shortcut assigned (destructive action requires explicit user action)
- **Smart Placement**: Positioned before "Discard Timer" in action panel for both running and paused timers

### 🔧 Technical Improvements
- **Reduced Duplication**: Extracted raw API call functions that can be reused across actions
- **Better Maintainability**: API endpoint changes now only need to be made in one place
- **TypeScript Support**: Proper typing throughout with ProjectType parameters

### 📚 Documentation
- **Constants**: Added toast messages for reset timer success/error states
- **Code Organization**: Clean separation between internal API functions and public actions

## Technical Details

The reset timer flow:
1. Discards current timer (without saving time)
2. Immediately starts fresh timer on same project
3. Only proceeds to start timer if discard succeeds
4. Shows combined success/error messages for reset operation

### API Endpoints
- `DELETE /projects/{id}/timer` - Discard current timer
- `PUT /projects/{id}/timer/start` - Start fresh timer

## Testing

- ✅ Linting passes (npm run lint)
- ✅ Manual testing completed for both running and paused timers
- ✅ Error handling verified (if discard fails, start is not attempted)
- ✅ Toast messages display correctly

## Screenshots

The reset action appears in the ActionPanel with:
- Clockwise arrow icon (Icon.ArrowClockwise)
- Destructive red styling
- Works on both running and paused timer states
- Positioned between "Log Timer" and "Discard Timer" actions