### PR TITLE
docs: remove specific dependency versions from documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,8 +211,12 @@ describe("useTimerActions", () => {
 
 ### Key Dependencies
 
-- `@raycast/api` - Raycast UI components and utilities
-- `@raycast/utils` - React hooks (`useFetch`, `useFetch` with caching)
-- React 18.3 - Component framework
-- TypeScript 5.4+ - Type safety
-- Jest + ts-jest - Testing framework
+- [`@raycast/api`](https://developers.raycast.com/api-reference) - Raycast UI components and utilities
+- [`@raycast/utils`](https://www.npmjs.com/package/@raycast/utils) - React hooks (`useFetch`, `useFetch` with caching)
+- [`react`](https://react.dev/) - Component framework
+- [`typescript`](https://www.typescriptlang.org/) - Type safety
+- [`jest`](https://jestjs.io/) - Testing framework
+- [`@types/react`](https://www.npmjs.com/package/@types/react) - React type definitions
+- [`@types/node`](https://www.npmjs.com/package/@types/node) - Node.js type definitions
+- [`eslint`](https://eslint.org/) - Code linting
+- [`prettier`](https://prettier.io/) - Code formatting

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ graph TD
 
 - [Raycast](https://raycast.com/) installed on your Mac
 - Noko account with API access
-- Node.js 16+ for development
+- Node.js (LTS) for development
 
 ### Installation
 
@@ -202,7 +202,7 @@ To use this plugin, you will need a **Personal Access Token (PAT)** from Noko. I
 ### System Requirements
 
 - **macOS** 10.15+ (Catalina or later)
-- **Raycast** 1.0+
+- **Raycast** Latest version
 - **Noko Account** with API access
 - **Personal Access Token** from Noko settings
 


### PR DESCRIPTION
## Summary

- Removed version numbers from Key Dependencies section in AGENTS.md
- Added documentation links for all dependencies  
- Updated Node.js requirement from "16+" to "(LTS)" version
- Updated Raycast requirement from "1.0+" to "Latest version"

This allows the documentation to stay up-to-date as dependencies evolve without requiring manual updates to version numbers.