### PR TITLE
fix(ci): update opencode workflow to use GitHub token and skip dependabot

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -16,8 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: anomalyco/opencode/github@v1.1.52
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub token for authentication in opencode-review workflow
- Skip opencode AI review for Dependabot pull requests

## Changes
- Replace `persist-credentials: false` with explicit `token` parameter
- Add conditional check to skip Dependabot PRs (`dependabot[bot]`)