### PR TITLE
fix(timers): sort timers by state priority (running first)

### DIFF
--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -2,6 +2,7 @@ import { useFetch } from "@raycast/utils";
 import { useMemo } from "react";
 import { dateOnTimezone } from "../utils";
 import { apiClient } from "../lib/api-client";
+import { getTimerStatePriority } from "../utils/timer-utils";
 import { TimerType, EntryType, ProjectType, TagType } from "../types";
 
 const NOKO_BASE_URL = "https://api.nokotime.com/v2";
@@ -38,8 +39,19 @@ export const useTimers = () => {
   } = useApiData<TimerType[]>("/timers");
 
   const timers = useMemo(() => {
-    return apiTimers || [];
-  }, [apiTimers]);
+    if (!apiTimers) return [];
+
+    return [...apiTimers].sort((a, b) => {
+      const priorityA = getTimerStatePriority(a.state);
+      const priorityB = getTimerStatePriority(b.state);
+
+      if (priorityA !== priorityB) {
+        return priorityA - priorityB;
+      }
+
+      return a.project.name.localeCompare(b.project.name);
+    });
+  }, [apiTimers, apiTimers?.map((t) => t.state).join(",")]);
 
   return {
     data: timers,


### PR DESCRIPTION
## Summary
- Add sorting logic to useTimers hook to prioritize running timers first, then paused timers
- Secondary sort by project name for consistent ordering within each state category
- Add state-based dependency to useMemo to ensure re-sorting occurs immediately when any timer's state changes

## Changes
- Modified `src/hooks/useApiData.ts` to sort timers by state priority using existing `getTimerStatePriority` utility
- Added `apiTimers?.map((t) => t.state).join(",")` to useMemo dependencies to trigger re-sorting on state changes

## Behavior
- Running timers always appear at the top (priority 1)
- Paused/stopped timers appear second (priority 2)
- Projects without timers continue to appear last
- Timers are alphabetically sorted by project name within each state category
- Timer ordering updates immediately when starting/pausing a timer