### PR TITLE
fix(hooks): remove redundant useMemo dependency in useTimers

### DIFF
--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -51,7 +51,7 @@ export const useTimers = () => {
 
       return a.project.name.localeCompare(b.project.name);
     });
-  }, [apiTimers, apiTimers?.map((t) => t.state).join(",")]);
+  }, [apiTimers]);
 
   return {
     data: timers,


### PR DESCRIPTION
## Summary
Remove unnecessary string computation from `useMemo` dependencies in `useTimers` hook. The `apiTimers` array is already tracked, so the computed string `apiTimers?.map((t) => t.state).join(",")` caused redundant computation on every render.

## Changes
- Simplified useMemo dependency array from `[apiTimers, apiTimers?.map((t) => t.state).join(",")]` to `[apiTimers]`

## Impact
- Eliminates redundant computation on every render
- Improves performance by avoiding unnecessary map and join operations
- Maintains same memoization behavior since array reference changes are already tracked