### PR TITLE
fix: add per_page=100 to projects API to fix pagination cutoff

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@ X-NokoToken: your_personal_access_token
 
 ### Projects
 
-- **GET** `/projects?enabled=true` - Fetch enabled projects
+- **GET** `/projects?enabled=true&per_page=100` - Fetch enabled projects (100 max per page; default is 30)
 - **GET** `/projects/{id}/timer/start` - Start timer for project
 - **PUT** `/projects/{id}/timer/start` - Start timer for project
 - **PUT** `/projects/{id}/timer` - Pause/stop timer

--- a/docs/bruno/Noko/Projects.bru
+++ b/docs/bruno/Noko/Projects.bru
@@ -5,13 +5,14 @@ meta {
 }
 
 get {
-  url: {{domain}}/projects?enabled=true
+  url: {{domain}}/projects?enabled=true&per_page=100
   body: none
   auth: inherit
 }
 
 params:query {
   enabled: true
+  per_page: 100
 }
 
 headers {

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -62,7 +62,7 @@ export const useTimers = () => {
 };
 
 export const useProjects = () => {
-  return useApiData<ProjectType[]>("/projects?enabled=true");
+  return useApiData<ProjectType[]>("/projects?enabled=true&per_page=100");
 };
 
 export const useTags = () => {


### PR DESCRIPTION
## Problem

Noko API defaults to 30 projects per page. Accounts with more than 30 enabled projects silently lose everything past page 1. \"The Stabilizers\" was project #31+ alphabetically, so it never appeared in the dropdown.

## Fix

Add `per_page=100` to the `/projects?enabled=true` call. Noko API supports up to 100 per page, which covers realistic account sizes without needing pagination logic.

## Changes

- `src/hooks/useApiData.ts` - add `per_page=100` query param
- `docs/bruno/Noko/Projects.bru` - update Bruno collection to match
- `docs/API.md` - document the default cap and fix

## Testing

Verified via direct API call that the default returns 30 projects and \"The Stabilizers\" is absent, while `per_page=100` returns 37 and includes it.