### PR TITLE
fix(entries): fix project change, date shift, and tag duplication in timer/edit flows

### DIFF
--- a/src/__tests__/description-utils.test.ts
+++ b/src/__tests__/description-utils.test.ts
@@ -1,4 +1,4 @@
-import { combineDescriptionAndTags } from "../utils/description-utils";
+import { combineDescriptionAndTags, stripTagsFromDescription } from "../utils/description-utils";
 
 describe("combineDescriptionAndTags", () => {
   it("combines description and tags with a space", () => {
@@ -22,5 +22,31 @@ describe("combineDescriptionAndTags", () => {
 
   it("handles single tag", () => {
     expect(combineDescriptionAndTags("desc", ["tag"])).toBe("desc tag");
+  });
+});
+
+describe("stripTagsFromDescription", () => {
+  it("removes hashtag tokens from description", () => {
+    expect(stripTagsFromDescription("fixed bug #backend #urgent")).toBe("fixed bug");
+  });
+
+  it("returns description unchanged when no hashtags", () => {
+    expect(stripTagsFromDescription("fixed bug")).toBe("fixed bug");
+  });
+
+  it("returns empty string when only hashtags", () => {
+    expect(stripTagsFromDescription("#backend #urgent")).toBe("");
+  });
+
+  it("removes hashtag in the middle", () => {
+    expect(stripTagsFromDescription("fixed #backend bug")).toBe("fixed bug");
+  });
+
+  it("trims extra whitespace after removal", () => {
+    expect(stripTagsFromDescription("  fixed bug #backend  ")).toBe("fixed bug");
+  });
+
+  it("handles empty string", () => {
+    expect(stripTagsFromDescription("")).toBe("");
   });
 });

--- a/src/__tests__/description-utils.test.ts
+++ b/src/__tests__/description-utils.test.ts
@@ -1,4 +1,7 @@
-import { combineDescriptionAndTags, stripTagsFromDescription } from "../utils/description-utils";
+import {
+  combineDescriptionAndTags,
+  stripTagsFromDescription,
+} from "../utils/description-utils";
 
 describe("combineDescriptionAndTags", () => {
   it("combines description and tags with a space", () => {
@@ -27,7 +30,9 @@ describe("combineDescriptionAndTags", () => {
 
 describe("stripTagsFromDescription", () => {
   it("removes hashtag tokens from description", () => {
-    expect(stripTagsFromDescription("fixed bug #backend #urgent")).toBe("fixed bug");
+    expect(stripTagsFromDescription("fixed bug #backend #urgent")).toBe(
+      "fixed bug",
+    );
   });
 
   it("returns description unchanged when no hashtags", () => {
@@ -43,7 +48,9 @@ describe("stripTagsFromDescription", () => {
   });
 
   it("trims extra whitespace after removal", () => {
-    expect(stripTagsFromDescription("  fixed bug #backend  ")).toBe("fixed bug");
+    expect(stripTagsFromDescription("  fixed bug #backend  ")).toBe(
+      "fixed bug",
+    );
   });
 
   it("handles empty string", () => {

--- a/src/__tests__/useTimerActions.test.ts
+++ b/src/__tests__/useTimerActions.test.ts
@@ -191,7 +191,7 @@ describe("useTimerActions", () => {
   });
 
   describe("logTimer", () => {
-    it("should log timer successfully", async () => {
+    it("should log timer successfully and return true", async () => {
       const entryData = {
         minutes: "60",
         project_name: "Test Project",
@@ -207,23 +207,20 @@ describe("useTimerActions", () => {
 
       const { result } = renderHook(() => useTimerActions());
 
+      let returnValue: boolean | undefined;
       await act(async () => {
-        await result.current.logTimer("1", entryData);
+        returnValue = await result.current.logTimer("1", entryData);
       });
 
+      expect(returnValue).toBe(true);
       expect(mockApiClient.put).toHaveBeenCalledWith("/projects/1/timer/log", {
         minutes: 60,
         description: "Worked on feature",
         entry_date: expect.any(String),
       });
-      expect(mockShowToast).toHaveBeenCalledWith({
-        style: Toast.Style.Success,
-        title: "Timer Logged",
-        message: "Timer logged for project",
-      });
     });
 
-    it("should handle log timer failure", async () => {
+    it("should return false and show error toast on failure", async () => {
       const entryData = {
         minutes: "60",
         project_name: "Test Project",
@@ -239,10 +236,12 @@ describe("useTimerActions", () => {
 
       const { result } = renderHook(() => useTimerActions());
 
+      let returnValue: boolean | undefined;
       await act(async () => {
-        await result.current.logTimer("1", entryData);
+        returnValue = await result.current.logTimer("1", entryData);
       });
 
+      expect(returnValue).toBe(false);
       expect(mockShowToast).toHaveBeenCalledWith({
         style: Toast.Style.Failure,
         title: "Failed to Log Timer",

--- a/src/hooks/useEntries.ts
+++ b/src/hooks/useEntries.ts
@@ -15,7 +15,7 @@ const useEntries = () => {
     if (!data || !Array.isArray(data)) {
       return [];
     }
-    return entryDecorator(data);
+return entryDecorator(data);
   }, [data]);
 
   return {

--- a/src/hooks/useEntries.ts
+++ b/src/hooks/useEntries.ts
@@ -15,7 +15,7 @@ const useEntries = () => {
     if (!data || !Array.isArray(data)) {
       return [];
     }
-return entryDecorator(data);
+    return entryDecorator(data);
   }, [data]);
 
   return {

--- a/src/hooks/useTimerActions.ts
+++ b/src/hooks/useTimerActions.ts
@@ -116,7 +116,7 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
   );
 
   const logTimer = useCallback(
-    async (projectId: string, entryData: EntryFormData) => {
+    async (projectId: string, entryData: EntryFormData): Promise<boolean> => {
       const payload = {
         minutes: parseTimeInput(entryData.minutes),
         description: combineDescriptionAndTags(
@@ -126,16 +126,16 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
         entry_date: dateOnTimezone(entryData.date),
       };
 
-      await handleApiCall(
-        () => apiClient.put(`/projects/${projectId}/timer/log`, payload),
-        {
-          errorTitle: TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER,
-          successTitle: TOAST_MESSAGES.SUCCESS.TIMER_LOGGED,
-          successMessage: `Timer logged for project`,
-        },
-      );
+      const result = await apiClient.put(`/projects/${projectId}/timer/log`, payload);
+
+      if (!result.success) {
+        showErrorToast(TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER, result.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR);
+        return false;
+      }
+
+      return true;
     },
-    [handleApiCall],
+    [],
   );
 
   return {

--- a/src/hooks/useTimerActions.ts
+++ b/src/hooks/useTimerActions.ts
@@ -126,10 +126,16 @@ export const useTimerActions = (options: UseTimerActionsOptions = {}) => {
         entry_date: dateOnTimezone(entryData.date),
       };
 
-      const result = await apiClient.put(`/projects/${projectId}/timer/log`, payload);
+      const result = await apiClient.put(
+        `/projects/${projectId}/timer/log`,
+        payload,
+      );
 
       if (!result.success) {
-        showErrorToast(TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER, result.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR);
+        showErrorToast(
+          TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER,
+          result.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR,
+        );
         return false;
       }
 

--- a/src/utils/description-utils.ts
+++ b/src/utils/description-utils.ts
@@ -4,3 +4,7 @@ export const combineDescriptionAndTags = (
 ): string => {
   return description.concat(" ", tags.join(" ")).trim();
 };
+
+export const stripTagsFromDescription = (description: string): string => {
+  return description.replace(/#\S+/g, "").replace(/\s+/g, " ").trim();
+};

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -1,9 +1,4 @@
-import {
-  Form,
-  ActionPanel,
-  Action,
-  Icon,
-} from "@raycast/api";
+import { Form, ActionPanel, Action, Icon } from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
 import { EntryFormData, ProjectType } from "../types";
 import { useProjects, useTags, useTimer } from "../hooks/useApiData";
@@ -59,20 +54,31 @@ export const AddEntryView = ({
     async (values: EntryFormData) => {
       try {
         if (isTimerMode) {
-          const selectedProject = projects.find((p) => p.name === values.project_name);
-          const projectChanged = selectedProject && selectedProject.id !== project.id;
+          const selectedProject = projects.find(
+            (p) => p.name === values.project_name,
+          );
+          const projectChanged =
+            selectedProject && selectedProject.id !== project.id;
 
           if (projectChanged) {
-            const discarded = await apiClient.delete(`/projects/${project.id}/timer`);
+            const discarded = await apiClient.delete(
+              `/projects/${project.id}/timer`,
+            );
             if (!discarded.success) {
-              showErrorToast(TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER, discarded.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR);
+              showErrorToast(
+                TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER,
+                discarded.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR,
+              );
               return;
             }
             await submitEntry(values);
           } else {
             const ok = await logTimer(project.id, values);
             if (!ok) return;
-            showSuccessToast(TOAST_MESSAGES.SUCCESS.TIMER_LOGGED, `Timer logged for ${project.name}`);
+            showSuccessToast(
+              TOAST_MESSAGES.SUCCESS.TIMER_LOGGED,
+              `Timer logged for ${project.name}`,
+            );
             onSubmit?.();
           }
         } else {
@@ -80,7 +86,9 @@ export const AddEntryView = ({
         }
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+          error instanceof Error
+            ? error.message
+            : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
         showErrorToast(TOAST_MESSAGES.ERROR.INVALID_INPUT, errorMessage);
       }
     },

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -2,18 +2,19 @@ import {
   Form,
   ActionPanel,
   Action,
-  showToast,
-  Toast,
   Icon,
 } from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
 import { EntryFormData, ProjectType } from "../types";
 import { useProjects, useTags, useTimer } from "../hooks/useApiData";
 import { useEntrySubmission, useTimerActions } from "../hooks";
+import { apiClient } from "../lib/api-client";
 import {
   formatMinutesAsTime,
   convertElapsedTimeToMinutes,
   getElapsedTime,
+  showSuccessToast,
+  showErrorToast,
 } from "../utils";
 import { TOAST_MESSAGES, TIME_DEFAULTS, FORM_MESSAGES } from "../constants";
 
@@ -36,18 +37,14 @@ export const AddEntryView = ({
   const { submitEntry } = useEntrySubmission({
     onSuccess: onSubmit,
   });
-  const { logTimer } = useTimerActions({
-    onSuccess: onSubmit,
-  });
+  const { logTimer } = useTimerActions();
 
-  // Determine if we're logging a timer or creating a manual entry
   const isTimerMode = project !== null;
 
   const [minutesValue, setMinutesValue] = useState<string>(
     TIME_DEFAULTS.DEFAULT_TIME_FORMAT,
   );
 
-  // Update minutes value when timer data is loaded
   useEffect(() => {
     if (isTimerMode && timer && !timerLoading) {
       const currentTime = new Date();
@@ -62,26 +59,32 @@ export const AddEntryView = ({
     async (values: EntryFormData) => {
       try {
         if (isTimerMode) {
-          const selectedProject =
-            projects.find((p) => p.name === values.project_name) ?? project;
-          await logTimer(selectedProject.id, values);
+          const selectedProject = projects.find((p) => p.name === values.project_name);
+          const projectChanged = selectedProject && selectedProject.id !== project.id;
+
+          if (projectChanged) {
+            const discarded = await apiClient.delete(`/projects/${project.id}/timer`);
+            if (!discarded.success) {
+              showErrorToast(TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER, discarded.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR);
+              return;
+            }
+            await submitEntry(values);
+          } else {
+            const ok = await logTimer(project.id, values);
+            if (!ok) return;
+            showSuccessToast(TOAST_MESSAGES.SUCCESS.TIMER_LOGGED, `Timer logged for ${project.name}`);
+            onSubmit?.();
+          }
         } else {
           await submitEntry(values);
         }
       } catch (error) {
         const errorMessage =
-          error instanceof Error
-            ? error.message
-            : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
-
-        showToast({
-          style: Toast.Style.Failure,
-          title: TOAST_MESSAGES.ERROR.INVALID_INPUT,
-          message: errorMessage,
-        });
+          error instanceof Error ? error.message : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+        showErrorToast(TOAST_MESSAGES.ERROR.INVALID_INPUT, errorMessage);
       }
     },
-    [isTimerMode, project, projects, logTimer, submitEntry],
+    [isTimerMode, project, projects, logTimer, submitEntry, onSubmit],
   );
 
   const projectOptions = useMemo(() => {
@@ -117,7 +120,7 @@ export const AddEntryView = ({
       <Form.Dropdown
         id="project_name"
         title="Project"
-        defaultValue={isTimerMode && project ? project.name : ""}
+        defaultValue={project?.name ?? ""}
         storeValue={!isTimerMode}
         autoFocus={!isTimerMode}
         info={FORM_MESSAGES.PROJECT.INFO}

--- a/src/views/EditEntryView.tsx
+++ b/src/views/EditEntryView.tsx
@@ -1,9 +1,4 @@
-import {
-  Form,
-  ActionPanel,
-  Action,
-  Icon,
-} from "@raycast/api";
+import { Form, ActionPanel, Action, Icon } from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
 import { EntryType, ProjectType } from "../types";
 import { useProjects, useTags } from "../hooks/useApiData";
@@ -78,7 +73,9 @@ export const EditEntryView = ({
       } catch (error) {
         // parseTimeInput throws on invalid input
         const errorMessage =
-          error instanceof Error ? error.message : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+          error instanceof Error
+            ? error.message
+            : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
         showErrorToast(TOAST_MESSAGES.ERROR.INVALID_INPUT, errorMessage);
       }
     },

--- a/src/views/EditEntryView.tsx
+++ b/src/views/EditEntryView.tsx
@@ -3,8 +3,6 @@ import {
   ActionPanel,
   Action,
   Icon,
-  showToast,
-  Toast,
 } from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
 import { EntryType, ProjectType } from "../types";
@@ -12,9 +10,11 @@ import { useProjects, useTags } from "../hooks/useApiData";
 import { useEntryActions } from "../hooks";
 import {
   combineDescriptionAndTags,
+  stripTagsFromDescription,
   dateOnTimezone,
   formatMinutesAsTime,
   parseTimeInput,
+  showErrorToast,
 } from "../utils";
 import { FORM_MESSAGES, TOAST_MESSAGES } from "../constants";
 
@@ -58,11 +58,10 @@ export const EditEntryView = ({
         );
 
         if (!selectedProject) {
-          showToast({
-            style: Toast.Style.Failure,
-            title: TOAST_MESSAGES.ERROR.INVALID_INPUT,
-            message: `Project "${values.project_name}" not found. Please try again.`,
-          });
+          showErrorToast(
+            TOAST_MESSAGES.ERROR.INVALID_INPUT,
+            `Project "${values.project_name}" not found. Please try again.`,
+          );
           return;
         }
 
@@ -79,15 +78,8 @@ export const EditEntryView = ({
       } catch (error) {
         // parseTimeInput throws on invalid input
         const errorMessage =
-          error instanceof Error
-            ? error.message
-            : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
-
-        showToast({
-          style: Toast.Style.Failure,
-          title: TOAST_MESSAGES.ERROR.INVALID_INPUT,
-          message: errorMessage,
-        });
+          error instanceof Error ? error.message : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
+        showErrorToast(TOAST_MESSAGES.ERROR.INVALID_INPUT, errorMessage);
       }
     },
     [entry, projects, editEntry],
@@ -111,6 +103,7 @@ export const EditEntryView = ({
 
   return (
     <Form
+      key={entry.id}
       actions={
         <ActionPanel>
           <Action.SubmitForm title="Save Entry" onSubmit={handleSubmit} />
@@ -152,7 +145,7 @@ export const EditEntryView = ({
       <Form.TextArea
         id="description"
         title="Description"
-        defaultValue={entry.description}
+        defaultValue={stripTagsFromDescription(entry.description)}
         placeholder={FORM_MESSAGES.DESCRIPTION.PLACEHOLDER}
         info={FORM_MESSAGES.DESCRIPTION.INFO_MANUAL}
       />
@@ -175,7 +168,7 @@ export const EditEntryView = ({
       <Form.DatePicker
         id="date"
         title="Date"
-        defaultValue={new Date(entry.date)}
+        defaultValue={new Date(entry.date.replace(/-/g, "/"))}
         info={FORM_MESSAGES.DATE.INFO}
       />
     </Form>


### PR DESCRIPTION
## Summary

- **Log timer project change**: when user picks a different project before logging, the timer on the original project is discarded and the entry is created directly on the selected project via `POST /entries`
- **Edit entry date shift**: `new Date("2026-05-20")` was parsed as midnight UTC, shifting to yesterday in local timezone. Fixed by replacing `-` with `/` so it parses as local time
- **Tag duplication**: `entry.description` from the API already contains hashtags inline. Added `stripTagsFromDescription` to strip them before populating the edit form, preventing double-append on save
- **Edit form field reset**: added `key={entry.id}` on `<Form>` so uncontrolled fields (project, description, tags, date) reset correctly when navigating between entries
- Replaced `showToast`/`Toast` with `showErrorToast` utility across both views
- Updated `logTimer` to return `boolean` instead of entry data (API returns empty body)

## Test plan

- [ ] Start timer on Project A, open log form, change dropdown to Project B, submit — entry should appear under Project B
- [ ] Start timer on Project A, log without changing project — entry appears under Project A with success toast
- [ ] Open edit form for an entry with tags — description field should not contain hashtags, tag picker should show them
- [ ] Save edited entry — tags should not be duplicated
- [ ] Open edit form, verify date matches the entry date (not shifted to yesterday)
- [ ] All 138 tests pass (`pnpm test`)