### PR TITLE
feat(entries): show lock icon on approved entries

### DIFF
--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -140,4 +140,17 @@ describe("EntryItem approved/locked indicator", () => {
     const canEditOrDelete = !entry.approved_by;
     expect(canEditOrDelete).toBe(true);
   });
+
+  it("handleEditEntry guard: approved entry cannot be edited", () => {
+    const entry = makeEntry({ approved_by: makeApprovedBy() });
+    // Mirrors the guard in timers.tsx handleEditEntry
+    const wouldNavigate = !entry.approved_by;
+    expect(wouldNavigate).toBe(false);
+  });
+
+  it("handleEditEntry guard: unapproved entry can be edited", () => {
+    const entry = makeEntry({ approved_by: null });
+    const wouldNavigate = !entry.approved_by;
+    expect(wouldNavigate).toBe(true);
+  });
 });

--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -1,5 +1,16 @@
-import { EntryType } from "../types";
+import { EntryType, ApprovedByType } from "../types";
 import { SUMMARY_COLORS } from "../constants";
+
+const makeApprovedBy = (
+  overrides: Partial<ApprovedByType> = {},
+): ApprovedByType => ({
+  id: "a1",
+  email: "approver@example.com",
+  first_name: "Alice",
+  last_name: "Smith",
+  profile_image_url: "",
+  ...overrides,
+});
 
 const makeEntry = (overrides: Partial<EntryType> = {}): EntryType => ({
   id: "1",
@@ -82,5 +93,40 @@ describe("EntryItem time accessory", () => {
     expect(makeEntry({ formatted_minutes: "2:30" }).formatted_minutes).toBe(
       "2:30",
     );
+  });
+});
+
+// Mirrors the approved_by accessory tooltip logic in EntryItem
+const getApprovalTooltip = (entry: EntryType): string | null => {
+  if (!entry.approved_by) return null;
+  const { first_name, last_name } = entry.approved_by;
+  return `Approved by ${first_name} ${last_name}`;
+};
+
+describe("EntryItem approved/locked indicator", () => {
+  it("returns null tooltip when entry is not approved", () => {
+    const entry = makeEntry({ approved_by: null });
+    expect(getApprovalTooltip(entry)).toBeNull();
+  });
+
+  it("returns tooltip with approver name when entry is approved", () => {
+    const approvedBy = makeApprovedBy({
+      first_name: "Alice",
+      last_name: "Smith",
+    });
+    const entry = makeEntry({ approved_by: approvedBy });
+    expect(getApprovalTooltip(entry)).toBe("Approved by Alice Smith");
+  });
+
+  it("shows lock icon and blocks edit/delete when approved", () => {
+    const entry = makeEntry({ approved_by: makeApprovedBy() });
+    expect(entry.approved_by).not.toBeNull();
+    // Edit and delete actions are gated on !entry.approved_by
+    expect(!entry.approved_by).toBe(false);
+  });
+
+  it("allows edit and delete when not approved", () => {
+    const entry = makeEntry({ approved_by: null });
+    expect(!entry.approved_by).toBe(true);
   });
 });

--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -118,15 +118,26 @@ describe("EntryItem approved/locked indicator", () => {
     expect(getApprovalTooltip(entry)).toBe("Approved by Alice Smith");
   });
 
-  it("shows lock icon and blocks edit/delete when approved", () => {
-    const entry = makeEntry({ approved_by: makeApprovedBy() });
-    expect(entry.approved_by).not.toBeNull();
-    // Edit and delete actions are gated on !entry.approved_by
-    expect(!entry.approved_by).toBe(false);
+  it("approved entry has accessory with lock icon tooltip", () => {
+    const approvedBy = makeApprovedBy({
+      first_name: "Bob",
+      last_name: "Jones",
+    });
+    const entry = makeEntry({ approved_by: approvedBy });
+    const tooltip = getApprovalTooltip(entry);
+    expect(tooltip).toBe("Approved by Bob Jones");
   });
 
-  it("allows edit and delete when not approved", () => {
+  it("edit and delete actions gated: approved entry hides them", () => {
+    const entry = makeEntry({ approved_by: makeApprovedBy() });
+    // Both edit and delete are rendered only when !entry.approved_by
+    const canEditOrDelete = !entry.approved_by;
+    expect(canEditOrDelete).toBe(false);
+  });
+
+  it("edit and delete actions available for unapproved entries", () => {
     const entry = makeEntry({ approved_by: null });
-    expect(!entry.approved_by).toBe(true);
+    const canEditOrDelete = !entry.approved_by;
+    expect(canEditOrDelete).toBe(true);
   });
 });

--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -124,6 +124,14 @@ export const EntryItem = memo<EntryItemProps>(
           tintColor: entry.project.color,
         }}
         accessories={[
+          ...(entry.approved_by
+            ? [
+                {
+                  icon: Icon.Lock,
+                  tooltip: `Approved by ${entry.approved_by.first_name} ${entry.approved_by.last_name}`,
+                },
+              ]
+            : []),
           {
             icon: {
               source: Icon.Coins,

--- a/src/timers.tsx
+++ b/src/timers.tsx
@@ -25,8 +25,10 @@ export default function Command() {
 
   const openEntries = () => setScreen({ name: "entries" });
 
-  const openEditEntry = (entry: EntryType) =>
+  const openEditEntry = (entry: EntryType) => {
+    if (entry.approved_by) return;
     setScreen({ name: "edit-entry", entry });
+  };
 
   const goToTimers = () => setScreen(TIMERS_SCREEN);
 


### PR DESCRIPTION
## Summary

- Adds a lock icon accessory to `EntryItem` when `entry.approved_by` is set
- Tooltip shows "Approved by {first_name} {last_name}"
- Edit and delete actions already hidden for approved entries; lock icon makes this visible at a glance

## Test plan

- [ ] Open entries list — approved entries show a lock icon
- [ ] Hover lock icon — tooltip shows approver name
- [ ] Unapproved entries show no lock icon and have edit/delete actions
- [ ] Unit tests in `EntryItem.test.ts` verify tooltip text and gate logic