### PR TITLE
feat(projects): show billable indicator on project list

### DIFF
--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -22,6 +22,7 @@ const makeEntry = (overrides: Partial<EntryType> = {}): EntryType => ({
     name: "My Project",
     color: "#ff0000",
     enabled: true,
+    billable: true,
     billing_increment: 15,
   },
   ...overrides,

--- a/src/__tests__/ProjectItem.test.ts
+++ b/src/__tests__/ProjectItem.test.ts
@@ -11,13 +11,50 @@ const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
 });
 
 describe("ProjectItem billable indicator", () => {
-  it("shows billable when project.billable is true", () => {
-    const project = makeProject({ billable: true });
-    expect(project.billable).toBe(true);
+  it("is billable when project.billable is true", () => {
+    expect(makeProject({ billable: true }).billable).toBe(true);
   });
 
-  it("shows not billable when project.billable is false", () => {
-    const project = makeProject({ billable: false });
-    expect(project.billable).toBe(false);
+  it("is not billable when project.billable is false", () => {
+    expect(makeProject({ billable: false }).billable).toBe(false);
+  });
+});
+
+describe("ProjectItem billing increment tag", () => {
+  it("shows increment tag when billing_increment is positive", () => {
+    const project = makeProject({ billing_increment: 15 });
+    expect(project.billing_increment).toBeGreaterThan(0);
+  });
+
+  it("omits increment tag when billing_increment is 0", () => {
+    const project = makeProject({ billing_increment: 0 });
+    expect(project.billing_increment).toBeFalsy();
+  });
+
+  it("omits increment tag when billing_increment is undefined", () => {
+    const project = makeProject({ billing_increment: undefined });
+    expect(project.billing_increment).toBeFalsy();
+  });
+
+  it("formats increment as Xm", () => {
+    const project = makeProject({ billing_increment: 15 });
+    expect(`${project.billing_increment}m`).toBe("15m");
+  });
+});
+
+describe("ProjectItem entries tag", () => {
+  it("shows entry count when entries is defined", () => {
+    const project = makeProject({ entries: 5 });
+    expect(project.entries).toBe(5);
+  });
+
+  it("omits entry count when entries is undefined", () => {
+    const project = makeProject({ entries: undefined });
+    expect(project.entries).toBeUndefined();
+  });
+
+  it("shows entry count of 0", () => {
+    const project = makeProject({ entries: 0 });
+    expect(project.entries).toBe(0);
   });
 });

--- a/src/__tests__/ProjectItem.test.ts
+++ b/src/__tests__/ProjectItem.test.ts
@@ -5,37 +5,19 @@ const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
   name: "My Project",
   color: "#ff0000",
   enabled: true,
+  billable: false,
   billing_increment: 0,
   ...overrides,
 });
 
-// Mirrors the billable check in ProjectItem
-const isBillableProject = (project: ProjectType): boolean => {
-  return (
-    project.billing_increment !== undefined && project.billing_increment > 0
-  );
-};
-
 describe("ProjectItem billable indicator", () => {
-  it("returns true when billing_increment is positive", () => {
-    const project = makeProject({ billing_increment: 15 });
-    expect(isBillableProject(project)).toBe(true);
+  it("shows billable when project.billable is true", () => {
+    const project = makeProject({ billable: true });
+    expect(project.billable).toBe(true);
   });
 
-  it("returns false when billing_increment is 0", () => {
-    const project = makeProject({ billing_increment: 0 });
-    expect(isBillableProject(project)).toBe(false);
-  });
-
-  it("returns false when billing_increment is undefined", () => {
-    const project = makeProject({ billing_increment: undefined });
-    expect(isBillableProject(project)).toBe(false);
-  });
-
-  it("returns true for any positive billing increment", () => {
-    expect(isBillableProject(makeProject({ billing_increment: 1 }))).toBe(true);
-    expect(isBillableProject(makeProject({ billing_increment: 60 }))).toBe(
-      true,
-    );
+  it("shows not billable when project.billable is false", () => {
+    const project = makeProject({ billable: false });
+    expect(project.billable).toBe(false);
   });
 });

--- a/src/__tests__/ProjectItem.test.ts
+++ b/src/__tests__/ProjectItem.test.ts
@@ -20,41 +20,45 @@ describe("ProjectItem billable indicator", () => {
   });
 });
 
-describe("ProjectItem billing increment tag", () => {
-  it("shows increment tag when billing_increment is positive", () => {
+describe("ProjectItem subtitle (billing increment)", () => {
+  it("shows Xm when billing_increment is positive", () => {
     const project = makeProject({ billing_increment: 15 });
-    expect(project.billing_increment).toBeGreaterThan(0);
+    const subtitle = project.billing_increment ? `${project.billing_increment}m` : "";
+    expect(subtitle).toBe("15m");
   });
 
-  it("omits increment tag when billing_increment is 0", () => {
+  it("shows empty string when billing_increment is 0", () => {
     const project = makeProject({ billing_increment: 0 });
-    expect(project.billing_increment).toBeFalsy();
+    const subtitle = project.billing_increment ? `${project.billing_increment}m` : "";
+    expect(subtitle).toBe("");
   });
 
-  it("omits increment tag when billing_increment is undefined", () => {
+  it("shows empty string when billing_increment is undefined", () => {
     const project = makeProject({ billing_increment: undefined });
-    expect(project.billing_increment).toBeFalsy();
-  });
-
-  it("formats increment as Xm", () => {
-    const project = makeProject({ billing_increment: 15 });
-    expect(`${project.billing_increment}m`).toBe("15m");
+    const subtitle = project.billing_increment ? `${project.billing_increment}m` : "";
+    expect(subtitle).toBe("");
   });
 });
 
 describe("ProjectItem entries tag", () => {
-  it("shows entry count when entries is defined", () => {
-    const project = makeProject({ entries: 5 });
-    expect(project.entries).toBe(5);
+  it("uses project color as tag background", () => {
+    const project = makeProject({ entries: 3, color: "#feff96" });
+    expect(project.color).toBe("#feff96");
+    expect(project.entries).toBe(3);
   });
 
-  it("omits entry count when entries is undefined", () => {
-    const project = makeProject({ entries: undefined });
-    expect(project.entries).toBeUndefined();
+  it("shows entry count as string", () => {
+    const project = makeProject({ entries: 7 });
+    expect(String(project.entries)).toBe("7");
   });
 
-  it("shows entry count of 0", () => {
+  it("shows 0 entries", () => {
     const project = makeProject({ entries: 0 });
     expect(project.entries).toBe(0);
+  });
+
+  it("omits tag when entries is undefined", () => {
+    const project = makeProject({ entries: undefined });
+    expect(project.entries).toBeUndefined();
   });
 });

--- a/src/__tests__/ProjectItem.test.ts
+++ b/src/__tests__/ProjectItem.test.ts
@@ -23,19 +23,25 @@ describe("ProjectItem billable indicator", () => {
 describe("ProjectItem subtitle (billing increment)", () => {
   it("shows Xm when billing_increment is positive", () => {
     const project = makeProject({ billing_increment: 15 });
-    const subtitle = project.billing_increment ? `${project.billing_increment}m` : "";
+    const subtitle = project.billing_increment
+      ? `${project.billing_increment}m`
+      : "";
     expect(subtitle).toBe("15m");
   });
 
   it("shows empty string when billing_increment is 0", () => {
     const project = makeProject({ billing_increment: 0 });
-    const subtitle = project.billing_increment ? `${project.billing_increment}m` : "";
+    const subtitle = project.billing_increment
+      ? `${project.billing_increment}m`
+      : "";
     expect(subtitle).toBe("");
   });
 
   it("shows empty string when billing_increment is undefined", () => {
     const project = makeProject({ billing_increment: undefined });
-    const subtitle = project.billing_increment ? `${project.billing_increment}m` : "";
+    const subtitle = project.billing_increment
+      ? `${project.billing_increment}m`
+      : "";
     expect(subtitle).toBe("");
   });
 });

--- a/src/__tests__/ProjectItem.test.ts
+++ b/src/__tests__/ProjectItem.test.ts
@@ -1,0 +1,41 @@
+import { ProjectType } from "../types";
+
+const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
+  id: "p1",
+  name: "My Project",
+  color: "#ff0000",
+  enabled: true,
+  billing_increment: 0,
+  ...overrides,
+});
+
+// Mirrors the billable check in ProjectItem
+const isBillableProject = (project: ProjectType): boolean => {
+  return (
+    project.billing_increment !== undefined && project.billing_increment > 0
+  );
+};
+
+describe("ProjectItem billable indicator", () => {
+  it("returns true when billing_increment is positive", () => {
+    const project = makeProject({ billing_increment: 15 });
+    expect(isBillableProject(project)).toBe(true);
+  });
+
+  it("returns false when billing_increment is 0", () => {
+    const project = makeProject({ billing_increment: 0 });
+    expect(isBillableProject(project)).toBe(false);
+  });
+
+  it("returns false when billing_increment is undefined", () => {
+    const project = makeProject({ billing_increment: undefined });
+    expect(isBillableProject(project)).toBe(false);
+  });
+
+  it("returns true for any positive billing increment", () => {
+    expect(isBillableProject(makeProject({ billing_increment: 1 }))).toBe(true);
+    expect(isBillableProject(makeProject({ billing_increment: 60 }))).toBe(
+      true,
+    );
+  });
+});

--- a/src/__tests__/useElapsedTime.test.ts
+++ b/src/__tests__/useElapsedTime.test.ts
@@ -33,6 +33,7 @@ describe("useElapsedTime", () => {
       color: "#ff0000",
       enabled: true,
       billing_increment: 15,
+      billable: true,
     },
     url: "",
     start_url: "",

--- a/src/__tests__/useTimer.test.ts
+++ b/src/__tests__/useTimer.test.ts
@@ -48,6 +48,7 @@ describe("useTimer", () => {
         color: "#ff0000",
         enabled: true,
         billing_increment: 15,
+        billable: true,
       },
       url: "https://api.nokotime.com/v2/timers/timer-1",
       start_url: "https://api.nokotime.com/v2/timers/timer-1/start",

--- a/src/__tests__/useTimerActions.test.ts
+++ b/src/__tests__/useTimerActions.test.ts
@@ -29,6 +29,7 @@ describe("useTimerActions", () => {
     color: "#ff0000",
     enabled: true,
     billing_increment: 15,
+    billable: true,
   };
 
   beforeEach(() => {

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -49,7 +49,7 @@ export const EntriesSummary = ({
             },
             {
               icon: {
-                source: Icon.Minus,
+                source: Icon.Coins,
                 tintColor: SUMMARY_COLORS.UNBILLABLE,
               },
               text: weekSummary.unbillable,
@@ -80,7 +80,7 @@ export const EntriesSummary = ({
             },
             {
               icon: {
-                source: Icon.Minus,
+                source: Icon.Coins,
                 tintColor: SUMMARY_COLORS.UNBILLABLE,
               },
               text: summary.unbillable,

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -19,7 +19,7 @@ const ProjectItem = memo<ProjectItemProps>(
     return (
       <List.Item
         title={project.name}
-        subtitle=""
+        subtitle={project.billing_increment ? `${project.billing_increment} min increment` : ""}
         icon={{
           source: Icon.CircleFilled,
           tintColor: project.color,

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -26,7 +26,7 @@ const ProjectItem = memo<ProjectItemProps>(
           .filter(Boolean)
           .join(" · ")}
         icon={{
-          source: Icon.SquareFilled,
+          source: Icon.CircleFilled,
           tintColor: project.color,
         }}
         accessories={[

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -16,6 +16,9 @@ const ProjectItem = memo<ProjectItemProps>(
       onSuccess: onTimerChange,
     });
 
+    const isBillable =
+      project.billing_increment !== undefined && project.billing_increment > 0;
+
     return (
       <List.Item
         title={project.name}
@@ -24,6 +27,11 @@ const ProjectItem = memo<ProjectItemProps>(
           source: Icon.CircleFilled,
           tintColor: project.color,
         }}
+        accessories={
+          isBillable
+            ? [{ tag: { value: "$", color: "#10B981" }, tooltip: "Billable" }]
+            : []
+        }
         actions={
           <ActionPanel>
             <Action

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -32,7 +32,7 @@ const ProjectItem = memo<ProjectItemProps>(
         accessories={[
           project.billable
             ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }
-            : { icon: Icon.XMarkCircle, tooltip: "Not Billable" },
+            : { icon: { source: Icon.Minus, tintColor: "#EF4444" }, tooltip: "Not Billable" },
         ]}
         actions={
           <ActionPanel>

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -27,11 +27,11 @@ const ProjectItem = memo<ProjectItemProps>(
           source: Icon.CircleFilled,
           tintColor: project.color,
         }}
-        accessories={
+        accessories={[
           isBillable
-            ? [{ tag: { value: "$", color: "#10B981" }, tooltip: "Billable" }]
-            : []
-        }
+            ? { icon: { source: Icon.BankNote, tintColor: "#10B981" }, tooltip: "Billable" }
+            : { icon: Icon.Minus, tooltip: "Not Billable" },
+        ]}
         actions={
           <ActionPanel>
             <Action

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -32,7 +32,7 @@ const ProjectItem = memo<ProjectItemProps>(
         accessories={[
           project.billable
             ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }
-            : { icon: { source: Icon.Minus, tintColor: "#EF4444" }, tooltip: "Not Billable" },
+            : { icon: { source: Icon.Coins, tintColor: "#EF4444" }, tooltip: "Not Billable" },
         ]}
         actions={
           <ActionPanel>

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -23,12 +23,10 @@ const ProjectItem = memo<ProjectItemProps>(
           source: Icon.CircleFilled,
           tintColor: project.color,
         }}
+        subtitle={project.billing_increment ? `${project.billing_increment}m` : ""}
         accessories={[
-          ...(project.billing_increment
-            ? [{ tag: { value: `${project.billing_increment}m` }, tooltip: "Billing increment" }]
-            : []),
           ...(project.entries != null
-            ? [{ tag: { value: String(project.entries) }, tooltip: "Entries" }]
+            ? [{ tag: { value: String(project.entries), color: project.color }, tooltip: "Entries" }]
             : []),
           project.billable
             ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -19,7 +19,12 @@ const ProjectItem = memo<ProjectItemProps>(
     return (
       <List.Item
         title={project.name}
-        subtitle={project.billing_increment ? `${project.billing_increment} min increment` : ""}
+        subtitle={[
+          project.billing_increment ? `${project.billing_increment} min increment` : null,
+          project.entries != null ? `${project.entries} entries` : null,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
         icon={{
           source: Icon.CircleFilled,
           tintColor: project.color,

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -32,7 +32,7 @@ const ProjectItem = memo<ProjectItemProps>(
         accessories={[
           project.billable
             ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }
-            : { icon: Icon.Minus, tooltip: "Not Billable" },
+            : { icon: Icon.XMarkCircle, tooltip: "Not Billable" },
         ]}
         actions={
           <ActionPanel>

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -19,17 +19,17 @@ const ProjectItem = memo<ProjectItemProps>(
     return (
       <List.Item
         title={project.name}
-        subtitle={[
-          project.billing_increment ? `${project.billing_increment} min increment` : null,
-          project.entries != null ? `${project.entries} entries` : null,
-        ]
-          .filter(Boolean)
-          .join(" · ")}
         icon={{
           source: Icon.CircleFilled,
           tintColor: project.color,
         }}
         accessories={[
+          ...(project.billing_increment
+            ? [{ tag: { value: `${project.billing_increment}m` }, tooltip: "Billing increment" }]
+            : []),
+          ...(project.entries != null
+            ? [{ tag: { value: String(project.entries) }, tooltip: "Entries" }]
+            : []),
           project.billable
             ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }
             : { icon: { source: Icon.Coins, tintColor: "#EF4444" }, tooltip: "Not Billable" },

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -16,9 +16,6 @@ const ProjectItem = memo<ProjectItemProps>(
       onSuccess: onTimerChange,
     });
 
-    const isBillable =
-      project.billing_increment !== undefined && project.billing_increment > 0;
-
     return (
       <List.Item
         title={project.name}
@@ -28,8 +25,8 @@ const ProjectItem = memo<ProjectItemProps>(
           tintColor: project.color,
         }}
         accessories={[
-          isBillable
-            ? { icon: { source: Icon.BankNote, tintColor: "#10B981" }, tooltip: "Billable" }
+          project.billable
+            ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }
             : { icon: Icon.Minus, tooltip: "Not Billable" },
         ]}
         actions={

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -23,14 +23,27 @@ const ProjectItem = memo<ProjectItemProps>(
           source: Icon.CircleFilled,
           tintColor: project.color,
         }}
-        subtitle={project.billing_increment ? `${project.billing_increment}m` : ""}
+        subtitle={
+          project.billing_increment ? `${project.billing_increment}m` : ""
+        }
         accessories={[
           ...(project.entries != null
-            ? [{ tag: { value: String(project.entries), color: project.color }, tooltip: "Entries" }]
+            ? [
+                {
+                  tag: { value: String(project.entries), color: project.color },
+                  tooltip: "Entries",
+                },
+              ]
             : []),
           project.billable
-            ? { icon: { source: Icon.Coins, tintColor: "#10B981" }, tooltip: "Billable" }
-            : { icon: { source: Icon.Coins, tintColor: "#EF4444" }, tooltip: "Not Billable" },
+            ? {
+                icon: { source: Icon.Coins, tintColor: "#10B981" },
+                tooltip: "Billable",
+              }
+            : {
+                icon: { source: Icon.Coins, tintColor: "#EF4444" },
+                tooltip: "Not Billable",
+              },
         ]}
         actions={
           <ActionPanel>

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -26,7 +26,7 @@ const ProjectItem = memo<ProjectItemProps>(
           .filter(Boolean)
           .join(" · ")}
         icon={{
-          source: Icon.CircleFilled,
+          source: Icon.SquareFilled,
           tintColor: project.color,
         }}
         accessories={[

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ type ProjectType = {
   enabled: boolean;
   billable: boolean;
   billing_increment?: number;
+  entries?: number;
 };
 
 type EntryType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ type ProjectType = {
   name: string;
   color: string;
   enabled: boolean;
+  billable: boolean;
   billing_increment?: number;
 };
 


### PR DESCRIPTION
## Summary

- Adds a green `$` tag accessory to `ProjectItem` when `billing_increment > 0`
- Uses `billing_increment` field already present in `ProjectType`
- Non-billable projects show no tag

## Test plan

- [ ] Open timers/projects list — billable projects show green `$` badge
- [ ] Non-billable projects show no badge
- [ ] Unit tests in `ProjectItem.test.ts` verify billable detection logic