### PR TITLE
feat(timers): add confirmation modal for discard and reset

### DIFF
--- a/src/__tests__/TimerItem.test.ts
+++ b/src/__tests__/TimerItem.test.ts
@@ -6,6 +6,7 @@ const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
   name: "My Project",
   color: "#ff0000",
   enabled: true,
+  billable: true,
   billing_increment: 15,
   ...overrides,
 });

--- a/src/__tests__/TimerItem.test.ts
+++ b/src/__tests__/TimerItem.test.ts
@@ -1,0 +1,49 @@
+import { ProjectType } from "../types";
+
+const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
+  id: "p1",
+  name: "My Project",
+  color: "#ff0000",
+  enabled: true,
+  billing_increment: 15,
+  ...overrides,
+});
+
+// Mirrors the confirmation messages used in TimerItem
+const getDiscardConfirmMessage = (project: ProjectType): string => {
+  return `Are you sure you want to discard the timer for "${project.name}"? This cannot be undone.`;
+};
+
+const getResetConfirmMessage = (project: ProjectType): string => {
+  return `Are you sure you want to reset the timer for "${project.name}"? The current time will be lost.`;
+};
+
+describe("TimerItem confirmation dialogs", () => {
+  describe("discard timer confirmation", () => {
+    it("includes project name in discard message", () => {
+      const project = makeProject({ name: "Frontend Work" });
+      const message = getDiscardConfirmMessage(project);
+      expect(message).toContain("Frontend Work");
+    });
+
+    it("warns that action cannot be undone", () => {
+      const project = makeProject();
+      const message = getDiscardConfirmMessage(project);
+      expect(message).toContain("cannot be undone");
+    });
+  });
+
+  describe("reset timer confirmation", () => {
+    it("includes project name in reset message", () => {
+      const project = makeProject({ name: "Backend API" });
+      const message = getResetConfirmMessage(project);
+      expect(message).toContain("Backend API");
+    });
+
+    it("warns that current time will be lost", () => {
+      const project = makeProject();
+      const message = getResetConfirmMessage(project);
+      expect(message).toContain("current time will be lost");
+    });
+  });
+});

--- a/src/__tests__/TimerItem.test.ts
+++ b/src/__tests__/TimerItem.test.ts
@@ -1,4 +1,5 @@
 import { ProjectType } from "../types";
+import { TIMER_CONFIRM_MESSAGES } from "../constants";
 
 const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
   id: "p1",
@@ -9,26 +10,17 @@ const makeProject = (overrides: Partial<ProjectType> = {}): ProjectType => ({
   ...overrides,
 });
 
-// Mirrors the confirmation messages used in TimerItem
-const getDiscardConfirmMessage = (project: ProjectType): string => {
-  return `Are you sure you want to discard the timer for "${project.name}"? This cannot be undone.`;
-};
-
-const getResetConfirmMessage = (project: ProjectType): string => {
-  return `Are you sure you want to reset the timer for "${project.name}"? The current time will be lost.`;
-};
-
 describe("TimerItem confirmation dialogs", () => {
   describe("discard timer confirmation", () => {
     it("includes project name in discard message", () => {
       const project = makeProject({ name: "Frontend Work" });
-      const message = getDiscardConfirmMessage(project);
+      const message = TIMER_CONFIRM_MESSAGES.DISCARD.getMessage(project.name);
       expect(message).toContain("Frontend Work");
     });
 
     it("warns that action cannot be undone", () => {
       const project = makeProject();
-      const message = getDiscardConfirmMessage(project);
+      const message = TIMER_CONFIRM_MESSAGES.DISCARD.getMessage(project.name);
       expect(message).toContain("cannot be undone");
     });
   });
@@ -36,14 +28,14 @@ describe("TimerItem confirmation dialogs", () => {
   describe("reset timer confirmation", () => {
     it("includes project name in reset message", () => {
       const project = makeProject({ name: "Backend API" });
-      const message = getResetConfirmMessage(project);
+      const message = TIMER_CONFIRM_MESSAGES.RESET.getMessage(project.name);
       expect(message).toContain("Backend API");
     });
 
-    it("warns that current time will be lost", () => {
+    it("warns that recorded time will be cleared", () => {
       const project = makeProject();
-      const message = getResetConfirmMessage(project);
-      expect(message).toContain("current time will be lost");
+      const message = TIMER_CONFIRM_MESSAGES.RESET.getMessage(project.name);
+      expect(message).toContain("recorded time will be cleared");
     });
   });
 });

--- a/src/components/TimerItem.tsx
+++ b/src/components/TimerItem.tsx
@@ -9,6 +9,7 @@ import {
 } from "@raycast/api";
 import { memo, useMemo, useCallback } from "react";
 import { TimerStateEnum, TimerType } from "../types";
+import { TIMER_CONFIRM_MESSAGES } from "../constants";
 import { useTimerActions } from "../hooks/useTimerActions";
 import useElapsedTime from "../hooks/useElapsedTime";
 
@@ -35,10 +36,10 @@ const TimerItem = memo<TimerItemProps>(
 
     const handleDiscard = useCallback(async () => {
       const confirmed = await confirmAlert({
-        title: "Discard Timer",
-        message: `Are you sure you want to discard the timer for "${currentProject.name}"? This cannot be undone.`,
+        title: TIMER_CONFIRM_MESSAGES.DISCARD.TITLE,
+        message: TIMER_CONFIRM_MESSAGES.DISCARD.getMessage(currentProject.name),
         primaryAction: {
-          title: "Discard",
+          title: TIMER_CONFIRM_MESSAGES.DISCARD.ACTION,
           style: Alert.ActionStyle.Destructive,
         },
       });
@@ -49,9 +50,12 @@ const TimerItem = memo<TimerItemProps>(
 
     const handleReset = useCallback(async () => {
       const confirmed = await confirmAlert({
-        title: "Reset Timer",
-        message: `Are you sure you want to reset the timer for "${currentProject.name}"? The current time will be lost.`,
-        primaryAction: { title: "Reset", style: Alert.ActionStyle.Destructive },
+        title: TIMER_CONFIRM_MESSAGES.RESET.TITLE,
+        message: TIMER_CONFIRM_MESSAGES.RESET.getMessage(currentProject.name),
+        primaryAction: {
+          title: TIMER_CONFIRM_MESSAGES.RESET.ACTION,
+          style: Alert.ActionStyle.Destructive,
+        },
       });
       if (confirmed) {
         await resetTimer(currentProject);

--- a/src/components/TimerItem.tsx
+++ b/src/components/TimerItem.tsx
@@ -3,6 +3,7 @@ import {
   List,
   ActionPanel,
   Action,
+  Alert,
   Color,
   confirmAlert,
 } from "@raycast/api";
@@ -36,7 +37,10 @@ const TimerItem = memo<TimerItemProps>(
       const confirmed = await confirmAlert({
         title: "Discard Timer",
         message: `Are you sure you want to discard the timer for "${currentProject.name}"? This cannot be undone.`,
-        primaryAction: { title: "Discard", style: Action.Style.Destructive },
+        primaryAction: {
+          title: "Discard",
+          style: Alert.ActionStyle.Destructive,
+        },
       });
       if (confirmed) {
         await discardTimer(currentProject);
@@ -47,7 +51,7 @@ const TimerItem = memo<TimerItemProps>(
       const confirmed = await confirmAlert({
         title: "Reset Timer",
         message: `Are you sure you want to reset the timer for "${currentProject.name}"? The current time will be lost.`,
-        primaryAction: { title: "Reset", style: Action.Style.Destructive },
+        primaryAction: { title: "Reset", style: Alert.ActionStyle.Destructive },
       });
       if (confirmed) {
         await resetTimer(currentProject);

--- a/src/components/TimerItem.tsx
+++ b/src/components/TimerItem.tsx
@@ -1,5 +1,12 @@
-import { Icon, List, ActionPanel, Action, Color } from "@raycast/api";
-import { memo, useMemo } from "react";
+import {
+  Icon,
+  List,
+  ActionPanel,
+  Action,
+  Color,
+  confirmAlert,
+} from "@raycast/api";
+import { memo, useMemo, useCallback } from "react";
 import { TimerStateEnum, TimerType } from "../types";
 import { useTimerActions } from "../hooks/useTimerActions";
 import useElapsedTime from "../hooks/useElapsedTime";
@@ -25,6 +32,28 @@ const TimerItem = memo<TimerItemProps>(
 
     const subtitle = useMemo(() => elapsedTime, [elapsedTime]);
 
+    const handleDiscard = useCallback(async () => {
+      const confirmed = await confirmAlert({
+        title: "Discard Timer",
+        message: `Are you sure you want to discard the timer for "${currentProject.name}"? This cannot be undone.`,
+        primaryAction: { title: "Discard", style: Action.Style.Destructive },
+      });
+      if (confirmed) {
+        await discardTimer(currentProject);
+      }
+    }, [currentProject, discardTimer]);
+
+    const handleReset = useCallback(async () => {
+      const confirmed = await confirmAlert({
+        title: "Reset Timer",
+        message: `Are you sure you want to reset the timer for "${currentProject.name}"? The current time will be lost.`,
+        primaryAction: { title: "Reset", style: Action.Style.Destructive },
+      });
+      if (confirmed) {
+        await resetTimer(currentProject);
+      }
+    }, [currentProject, resetTimer]);
+
     const timerActions = useMemo(() => {
       if (timer.state === TimerStateEnum.Running) {
         return (
@@ -42,13 +71,13 @@ const TimerItem = memo<TimerItemProps>(
             <Action
               title="Reset Timer"
               icon={Icon.ArrowClockwise}
-              onAction={() => resetTimer(currentProject)}
+              onAction={handleReset}
               style={Action.Style.Destructive}
             />
             <Action
               title="Discard Timer"
               icon={Icon.Trash}
-              onAction={() => discardTimer(currentProject)}
+              onAction={handleDiscard}
               style={Action.Style.Destructive}
             />
           </>
@@ -71,13 +100,13 @@ const TimerItem = memo<TimerItemProps>(
           <Action
             title="Reset Timer"
             icon={Icon.ArrowClockwise}
-            onAction={() => resetTimer(currentProject)}
+            onAction={handleReset}
             style={Action.Style.Destructive}
           />
           <Action
             title="Discard Timer"
             icon={Icon.Trash}
-            onAction={() => discardTimer(currentProject)}
+            onAction={handleDiscard}
             style={Action.Style.Destructive}
           />
         </>
@@ -87,8 +116,8 @@ const TimerItem = memo<TimerItemProps>(
       currentProject,
       startTimer,
       pauseTimer,
-      discardTimer,
-      resetTimer,
+      handleDiscard,
+      handleReset,
       onLogTimer,
     ]);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,6 +62,22 @@ export const FORM_MESSAGES = {
   },
 } as const;
 
+// Timer confirmation dialog messages
+export const TIMER_CONFIRM_MESSAGES = {
+  DISCARD: {
+    TITLE: "Discard Timer",
+    ACTION: "Discard",
+    getMessage: (projectName: string) =>
+      `Are you sure you want to discard the timer for "${projectName}"? This cannot be undone.`,
+  },
+  RESET: {
+    TITLE: "Reset Timer",
+    ACTION: "Reset",
+    getMessage: (projectName: string) =>
+      `Are you sure you want to reset the timer for "${projectName}"? The recorded time will be cleared.`,
+  },
+} as const;
+
 // UI component messages
 export const UI_MESSAGES = {
   LOADING: {


### PR DESCRIPTION
## Summary

- Adds `confirmAlert` before discard and reset actions in `TimerItem`
- Both confirmations show the project name and describe what will happen
- Primary action is styled as `Destructive` in the modal
- Applies to both running and paused timer states

## Test plan

- [ ] Click "Discard Timer" on a running or paused timer — confirmation modal appears before discarding
- [ ] Click "Reset Timer" — confirmation modal appears before resetting
- [ ] Dismiss/cancel the modal — timer is not affected
- [ ] Confirm — timer is discarded/reset as expected
- [ ] Unit tests in `TimerItem.test.ts` verify confirmation message content