### PR TITLE
feat(entries): add duplicate entry action (cmd+D)

### DIFF
--- a/src/__tests__/duplicateEntry.test.ts
+++ b/src/__tests__/duplicateEntry.test.ts
@@ -36,7 +36,7 @@ const makeEntry = (overrides: Partial<EntryType> = {}): EntryType => ({
 const buildPrefill = (entry: EntryType) => ({
   minutesValue: formatMinutesAsTime(entry.minutes),
   description: stripTagsFromDescription(entry.description),
-  tags: entry.tags.map((t) => t.formatted_name),
+  tags: entry.tags?.map((t) => t.formatted_name) ?? [],
   projectName: entry.project.name,
 });
 
@@ -78,5 +78,23 @@ describe("duplicate entry pre-fill", () => {
     const prefill = buildPrefill(entry);
     expect(prefill.tags).toEqual([]);
     expect(prefill.description).toBe("clean description");
+  });
+
+  it("handles null tags gracefully", () => {
+    const entry = makeEntry({ tags: null as unknown as EntryType["tags"] });
+    const prefill = buildPrefill(entry);
+    expect(prefill.tags).toEqual([]);
+  });
+
+  it("handles empty description", () => {
+    const entry = makeEntry({ description: "" });
+    const prefill = buildPrefill(entry);
+    expect(prefill.description).toBe("");
+  });
+
+  it("handles description with only tags", () => {
+    const entry = makeEntry({ description: "#backend #urgent" });
+    const prefill = buildPrefill(entry);
+    expect(prefill.description).toBe("");
   });
 });

--- a/src/__tests__/duplicateEntry.test.ts
+++ b/src/__tests__/duplicateEntry.test.ts
@@ -1,0 +1,82 @@
+import { EntryType } from "../types";
+import { stripTagsFromDescription, formatMinutesAsTime } from "../utils";
+
+const makeEntry = (overrides: Partial<EntryType> = {}): EntryType => ({
+  id: "1",
+  date: "2026-05-01",
+  billable: true,
+  minutes: 90,
+  formatted_minutes: "1:30",
+  description: "fixed bug #backend #urgent",
+  approved_by: null,
+  approved_at: "",
+  user: {
+    id: "u1",
+    email: "user@example.com",
+    first_name: "Jane",
+    last_name: "Doe",
+    profile_image_url: "",
+  },
+  tags: [
+    { id: "t1", name: "backend", formatted_name: "#backend" },
+    { id: "t2", name: "urgent", formatted_name: "#urgent" },
+  ],
+  project: {
+    id: "p1",
+    name: "My Project",
+    color: "#ff0000",
+    enabled: true,
+    billable: true,
+    billing_increment: 15,
+  },
+  ...overrides,
+});
+
+// Mirrors the pre-fill logic applied in AddEntryView when prefillEntry is set
+const buildPrefill = (entry: EntryType) => ({
+  minutesValue: formatMinutesAsTime(entry.minutes),
+  description: stripTagsFromDescription(entry.description),
+  tags: entry.tags.map((t) => t.formatted_name),
+  projectName: entry.project.name,
+});
+
+describe("duplicate entry pre-fill", () => {
+  it("pre-fills minutes from the original entry", () => {
+    const entry = makeEntry({ minutes: 90 });
+    const prefill = buildPrefill(entry);
+    expect(prefill.minutesValue).toBe("1:30");
+  });
+
+  it("strips hashtags from description before pre-filling", () => {
+    const entry = makeEntry({ description: "fixed bug #backend #urgent" });
+    const prefill = buildPrefill(entry);
+    expect(prefill.description).toBe("fixed bug");
+  });
+
+  it("pre-fills tags from original entry", () => {
+    const entry = makeEntry();
+    const prefill = buildPrefill(entry);
+    expect(prefill.tags).toEqual(["#backend", "#urgent"]);
+  });
+
+  it("pre-fills project name from original entry", () => {
+    const entry = makeEntry({
+      project: {
+        id: "p2",
+        name: "Backend API",
+        color: "#blue",
+        enabled: true,
+        billable: true,
+      },
+    });
+    const prefill = buildPrefill(entry);
+    expect(prefill.projectName).toBe("Backend API");
+  });
+
+  it("handles entry with no tags", () => {
+    const entry = makeEntry({ tags: [], description: "clean description" });
+    const prefill = buildPrefill(entry);
+    expect(prefill.tags).toEqual([]);
+    expect(prefill.description).toBe("clean description");
+  });
+});

--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -11,6 +11,7 @@ interface EntryItemProps {
   onToggleDetail: () => void;
   onCancel?: () => void;
   onEdit?: (entry: EntryType) => void;
+  onDuplicate?: (entry: EntryType) => void;
 }
 
 export const EntryItem = memo<EntryItemProps>(
@@ -20,6 +21,7 @@ export const EntryItem = memo<EntryItemProps>(
     onToggleDetail,
     onCancel,
     onEdit,
+    onDuplicate,
   }: EntryItemProps) => {
     const { deleteEntry } = useEntryActions({
       onSuccess: () => {
@@ -140,7 +142,6 @@ export const EntryItem = memo<EntryItemProps>(
             <Action
               title={isShowingDetail ? "Hide Details" : "Show Details"}
               onAction={onToggleDetail}
-              shortcut={{ modifiers: ["cmd"], key: "d" }}
             />
             {!entry.approved_by && onEdit && (
               <Action
@@ -155,6 +156,14 @@ export const EntryItem = memo<EntryItemProps>(
                 title="Copy Description"
                 content={entry.description}
                 shortcut={{ modifiers: ["cmd"], key: "c" }}
+              />
+            )}
+            {onDuplicate && (
+              <Action
+                title="Duplicate Entry"
+                icon={Icon.CopyClipboard}
+                onAction={() => onDuplicate(entry)}
+                shortcut={{ modifiers: ["cmd"], key: "d" }}
               />
             )}
             {!entry.approved_by && (

--- a/src/timers.tsx
+++ b/src/timers.tsx
@@ -28,16 +28,18 @@ export default function Command() {
   const openEditEntry = (entry: EntryType) =>
     setScreen({ name: "edit-entry", entry });
 
+  const openDuplicateEntry = (entry: EntryType) =>
+    setScreen({ name: "add-entry", draft: { mode: "duplicate", entry } });
+
   const goToTimers = () => setScreen(TIMERS_SCREEN);
 
   if (screen.name === "add-entry") {
+    // Duplicating starts from the entries list, so return there on
+    // submit/cancel; manual and timer entries start from the timers list.
+    const done = screen.draft.mode === "duplicate" ? openEntries : goToTimers;
     return (
       <ErrorBoundary>
-        <AddEntryView
-          draft={screen.draft}
-          onSubmit={goToTimers}
-          onCancel={goToTimers}
-        />
+        <AddEntryView draft={screen.draft} onSubmit={done} onCancel={done} />
       </ErrorBoundary>
     );
   }
@@ -57,7 +59,11 @@ export default function Command() {
   if (screen.name === "entries") {
     return (
       <ErrorBoundary>
-        <EntriesView onCancel={goToTimers} onEditEntry={openEditEntry} />
+        <EntriesView
+          onCancel={goToTimers}
+          onEditEntry={openEditEntry}
+          onDuplicateEntry={openDuplicateEntry}
+        />
       </ErrorBoundary>
     );
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,11 +167,14 @@ type GoalProgressType = {
 };
 
 // Add Entry intent: discriminates between a fresh manual entry (default
-// time, regular submit) and logging a running timer (elapsed time prefill,
-// log-timer endpoint). Both always carry a preselected project.
+// time, regular submit), logging a running timer (elapsed time prefill,
+// log-timer endpoint), and duplicating an existing entry (form prefilled
+// from the source entry). Manual and log-timer carry a preselected project;
+// duplicate carries the source entry (its project is reused).
 type EntryDraft =
   | { mode: "manual"; project: ProjectType }
-  | { mode: "log-timer"; project: ProjectType };
+  | { mode: "log-timer"; project: ProjectType }
+  | { mode: "duplicate"; entry: EntryType };
 
 // ============================================================================
 // EXPORTS

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -191,7 +191,9 @@ export const AddEntryView = ({
         id="tags"
         title="Tags"
         defaultValue={
-          prefillEntry ? prefillEntry.tags.map((t) => t.formatted_name) : []
+          prefillEntry
+            ? (prefillEntry.tags?.map((t) => t.formatted_name) ?? [])
+            : []
         }
         info={FORM_MESSAGES.TAGS.INFO}
       >

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -1,6 +1,6 @@
 import { Form, ActionPanel, Action, Icon } from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
-import { EntryFormData, EntryDraft } from "../types";
+import { EntryFormData, EntryType, EntryDraft } from "../types";
 import { useProjects, useTags, useTimer } from "../hooks/useApiData";
 import { useEntrySubmission, useTimerActions } from "../hooks";
 import { apiClient } from "../lib/api-client";
@@ -10,6 +10,7 @@ import {
   getElapsedTime,
   showSuccessToast,
   showErrorToast,
+  stripTagsFromDescription,
 } from "../utils";
 import { TOAST_MESSAGES, TIME_DEFAULTS, FORM_MESSAGES } from "../constants";
 
@@ -24,8 +25,13 @@ export const AddEntryView = ({
   onSubmit,
   onCancel,
 }: AddEntryViewProps) => {
-  const { project } = draft;
   const isTimerMode = draft.mode === "log-timer";
+  // Duplicating reuses the source entry (project + prefilled fields); manual
+  // and log-timer carry their own preselected project on the draft.
+  const prefillEntry: EntryType | undefined =
+    draft.mode === "duplicate" ? draft.entry : undefined;
+  const project =
+    draft.mode === "duplicate" ? draft.entry.project : draft.project;
 
   const { data: projects = [] } = useProjects();
   const { data: tags = [] } = useTags();
@@ -37,13 +43,16 @@ export const AddEntryView = ({
   const { submitEntry } = useEntrySubmission({ onSuccess: onSubmit });
   const { logTimer } = useTimerActions();
 
-  // Manual entries default to the project's billing increment from the API
-  // (e.g. 5 or 15 min). Log-timer entries are overwritten by elapsed time
-  // in the effect below once the timer fetch resolves.
+  // Duplicated entries reuse the source entry's time. Manual entries default
+  // to the project's billing increment from the API (e.g. 5 or 15 min).
+  // Log-timer entries are overwritten by elapsed time in the effect below
+  // once the timer fetch resolves.
   const [minutesValue, setMinutesValue] = useState<string>(() =>
-    project.billing_increment && project.billing_increment > 0
-      ? formatMinutesAsTime(project.billing_increment)
-      : TIME_DEFAULTS.DEFAULT_TIME_FORMAT,
+    prefillEntry
+      ? formatMinutesAsTime(prefillEntry.minutes)
+      : project.billing_increment && project.billing_increment > 0
+        ? formatMinutesAsTime(project.billing_increment)
+        : TIME_DEFAULTS.DEFAULT_TIME_FORMAT,
   );
 
   useEffect(() => {
@@ -122,6 +131,7 @@ export const AddEntryView = ({
 
   return (
     <Form
+      key={prefillEntry?.id}
       actions={
         <ActionPanel>
           <Action.SubmitForm onSubmit={handleSubmit} />
@@ -163,6 +173,11 @@ export const AddEntryView = ({
       <Form.TextArea
         id="description"
         title="Description"
+        defaultValue={
+          prefillEntry
+            ? stripTagsFromDescription(prefillEntry.description)
+            : undefined
+        }
         placeholder={FORM_MESSAGES.DESCRIPTION.PLACEHOLDER}
         autoFocus
         info={
@@ -175,7 +190,9 @@ export const AddEntryView = ({
       <Form.TagPicker
         id="tags"
         title="Tags"
-        defaultValue={[]}
+        defaultValue={
+          prefillEntry ? prefillEntry.tags.map((t) => t.formatted_name) : []
+        }
         info={FORM_MESSAGES.TAGS.INFO}
       >
         {tagOptions.map((tag) => (

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -8,9 +8,14 @@ import { UI_MESSAGES } from "../constants";
 interface EntriesViewProps {
   onCancel?: () => void;
   onEditEntry?: (entry: EntryType) => void;
+  onDuplicateEntry?: (entry: EntryType) => void;
 }
 
-export const EntriesView = ({ onCancel, onEditEntry }: EntriesViewProps) => {
+export const EntriesView = ({
+  onCancel,
+  onEditEntry,
+  onDuplicateEntry,
+}: EntriesViewProps) => {
   const { isLoading, filter, filteredEntries, setFilter, error } = useEntries();
   const { data: weekEntries } = useWeekEntries();
   const { isShowingDetail, toggleDetail } = useDetailToggle(false);
@@ -42,9 +47,17 @@ export const EntriesView = ({ onCancel, onEditEntry }: EntriesViewProps) => {
         onToggleDetail={toggleDetail}
         onCancel={onCancel}
         onEdit={onEditEntry}
+        onDuplicate={onDuplicateEntry}
       />
     ));
-  }, [filteredEntries, isShowingDetail, toggleDetail, onCancel, onEditEntry]);
+  }, [
+    filteredEntries,
+    isShowingDetail,
+    toggleDetail,
+    onCancel,
+    onEditEntry,
+    onDuplicateEntry,
+  ]);
 
   return (
     <List


### PR DESCRIPTION
## Summary

- Adds "Duplicate Entry" action (cmd+D) to each entry in the list
- Opens `AddEntryView` pre-filled with the original entry's project, time, description (tags stripped), and tags
- Date defaults to today (new entry, not a copy of the original date)
- After submit/cancel, returns to the entries view

## Changes

- `EntryItem`: added `onDuplicate` prop and "Duplicate Entry" action; moved shortcut off "Show Details" to avoid conflict
- `AddEntryView`: added `prefillEntry?: EntryType` prop to pre-fill form fields
- `EntriesView`: threads `onDuplicateEntry` callback
- `timers.tsx`: manages `duplicatingEntry` state and wires navigate/cancel back to entries

## Test plan

- [ ] Select an entry, press `cmd+D` — form opens pre-filled with project, time, description, and tags
- [ ] Date should default to today, not the original entry's date
- [ ] Submit the form — new entry created, returns to entries view
- [ ] Cancel (cmd+[) — returns to entries view, no entry created
- [ ] Unit tests in `duplicateEntry.test.ts` verify pre-fill logic