### PR TITLE
feat(entries): add daily breakdown below week total

### DIFF
--- a/src/__tests__/getDailyBreakdown.test.ts
+++ b/src/__tests__/getDailyBreakdown.test.ts
@@ -1,0 +1,79 @@
+import { getDailyBreakdown } from "../utils/entry-utils";
+import { EntryType } from "../types";
+
+const makeEntry = (
+  date: string,
+  minutes: number,
+  overrides: Partial<EntryType> = {},
+): EntryType => ({
+  id: date + minutes,
+  date,
+  billable: true,
+  minutes,
+  formatted_minutes: "",
+  description: "",
+  approved_by: null,
+  approved_at: "",
+  user: {
+    id: "u1",
+    email: "user@example.com",
+    first_name: "Jane",
+    last_name: "Doe",
+    profile_image_url: "",
+  },
+  tags: [],
+  project: {
+    id: "p1",
+    name: "Project",
+    color: "#ff0000",
+    enabled: true,
+  },
+  ...overrides,
+});
+
+describe("getDailyBreakdown", () => {
+  it("returns empty array for empty entries", () => {
+    expect(getDailyBreakdown([])).toEqual([]);
+  });
+
+  it("groups entries by date and sums minutes", () => {
+    const entries = [
+      makeEntry("2026-05-19", 60),
+      makeEntry("2026-05-19", 30),
+      makeEntry("2026-05-20", 90),
+    ];
+    const result = getDailyBreakdown(entries);
+    expect(result).toHaveLength(2);
+    expect(result[0].date).toBe("2026-05-19");
+    expect(result[0].minutes).toBe(90);
+    expect(result[1].date).toBe("2026-05-20");
+    expect(result[1].minutes).toBe(90);
+  });
+
+  it("formats minutes correctly", () => {
+    const entries = [makeEntry("2026-05-19", 90)];
+    const result = getDailyBreakdown(entries);
+    expect(result[0].totalFormatted).toBe("01:30");
+  });
+
+  it("includes correct day label for known dates", () => {
+    // 2026-05-18 is a Monday
+    const entries = [makeEntry("2026-05-18", 60)];
+    const result = getDailyBreakdown(entries);
+    expect(result[0].dayLabel).toBe("Mon");
+  });
+
+  it("sorts rows by date ascending", () => {
+    const entries = [
+      makeEntry("2026-05-21", 30),
+      makeEntry("2026-05-19", 60),
+      makeEntry("2026-05-20", 90),
+    ];
+    const result = getDailyBreakdown(entries);
+    expect(result.map((r) => r.date)).toEqual([
+      "2026-05-19",
+      "2026-05-20",
+      "2026-05-21",
+    ]);
+  });
+});

--- a/src/__tests__/getDailyBreakdown.test.ts
+++ b/src/__tests__/getDailyBreakdown.test.ts
@@ -27,6 +27,7 @@ const makeEntry = (
     name: "Project",
     color: "#ff0000",
     enabled: true,
+    billable: true,
   },
   ...overrides,
 });
@@ -61,6 +62,16 @@ describe("getDailyBreakdown", () => {
     const entries = [makeEntry("2026-05-18", 60)];
     const result = getDailyBreakdown(entries);
     expect(result[0].dayLabel).toBe("Mon");
+  });
+
+  it("splits billable and unbillable minutes per day", () => {
+    const entries = [
+      makeEntry("2026-05-19", 60, { billable: true }),
+      makeEntry("2026-05-19", 30, { billable: false }),
+    ];
+    const result = getDailyBreakdown(entries);
+    expect(result[0].billable).toBe("01:00");
+    expect(result[0].unbillable).toBe("00:30");
   });
 
   it("sorts rows by date ascending", () => {

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -77,6 +77,7 @@ export const EntriesSummary = ({
       )}
       {weekSummary && weekSummary.exists && (
         <List.Item
+          id="summary-week"
           title={weekSummary.title}
           subtitle={weekSummary.subtitle}
           accessories={[

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -48,6 +48,7 @@ export const EntriesSummary = ({
     <List.Section title="Summary">
       {summary && summary.exists && (
         <List.Item
+          id="summary-today"
           title={summary.title}
           subtitle={summary.subtitle}
           accessories={[

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -57,7 +57,10 @@ export const EntriesSummary = ({
               text: summary.billable,
             },
             {
-              icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
+              icon: {
+                source: Icon.Coins,
+                tintColor: SUMMARY_COLORS.UNBILLABLE,
+              },
               text: summary.unbillable,
             },
           ]}
@@ -86,7 +89,10 @@ export const EntriesSummary = ({
               text: weekSummary.billable,
             },
             {
-              icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
+              icon: {
+                source: Icon.Coins,
+                tintColor: SUMMARY_COLORS.UNBILLABLE,
+              },
               text: weekSummary.unbillable,
             },
           ]}

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { EntryType } from "../types";
 import { getEntriesSummary, getWeekSummary, getDailyBreakdown } from "../utils";
 import { SUMMARY_COLORS } from "../constants";
+import { WeekDailyBreakdown } from "./WeekDailyBreakdown";
 
 interface EntriesSummaryProps {
   entries: EntryType[] | null;
@@ -45,21 +46,18 @@ export const EntriesSummary = ({
 
   return (
     <List.Section title="Summary">
-      {weekSummary && weekSummary.exists && (
+      {summary && summary.exists && (
         <List.Item
-          title={weekSummary.title}
-          subtitle={weekSummary.subtitle}
+          title={summary.title}
+          subtitle={summary.subtitle}
           accessories={[
             {
               icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
-              text: weekSummary.billable,
+              text: summary.billable,
             },
             {
-              icon: {
-                source: Icon.Coins,
-                tintColor: SUMMARY_COLORS.UNBILLABLE,
-              },
-              text: weekSummary.unbillable,
+              icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
+              text: summary.unbillable,
             },
           ]}
           actions={
@@ -76,40 +74,29 @@ export const EntriesSummary = ({
           }
         />
       )}
-      {dailyBreakdown.map((row) => (
+      {weekSummary && weekSummary.exists && (
         <List.Item
-          key={row.date}
-          title={`${row.dayLabel} ${row.date}   ${row.totalFormatted}`}
-          icon={Icon.Calendar}
+          title={weekSummary.title}
+          subtitle={weekSummary.subtitle}
           accessories={[
             {
               icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
-              text: row.billable,
+              text: weekSummary.billable,
             },
             {
               icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
-              text: row.unbillable,
+              text: weekSummary.unbillable,
             },
           ]}
-        />
-      ))}
-      {summary && summary.exists && (
-        <List.Item
-          title={summary.title}
-          subtitle={summary.subtitle}
-          accessories={[
-            {
-              icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
-              text: summary.billable,
-            },
-            {
-              icon: {
-                source: Icon.Coins,
-                tintColor: SUMMARY_COLORS.UNBILLABLE,
-              },
-              text: summary.unbillable,
-            },
-          ]}
+          actions={
+            <ActionPanel>
+              <Action.Push
+                title="View Daily Breakdown"
+                icon={Icon.Calendar}
+                target={<WeekDailyBreakdown rows={dailyBreakdown} />}
+              />
+            </ActionPanel>
+          }
         />
       )}
     </List.Section>

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -79,9 +79,18 @@ export const EntriesSummary = ({
       {dailyBreakdown.map((row) => (
         <List.Item
           key={row.date}
-          title={`${row.dayLabel} ${row.date}`}
-          subtitle={row.totalFormatted}
+          title={`${row.dayLabel} ${row.date}   ${row.totalFormatted}`}
           icon={Icon.Calendar}
+          accessories={[
+            {
+              icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
+              text: row.billable,
+            },
+            {
+              icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
+              text: row.unbillable,
+            },
+          ]}
         />
       ))}
       {summary && summary.exists && (

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -1,7 +1,7 @@
 import { List, ActionPanel, Action, Icon } from "@raycast/api";
 import { useMemo } from "react";
 import { EntryType } from "../types";
-import { getEntriesSummary, getWeekSummary } from "../utils";
+import { getEntriesSummary, getWeekSummary, getDailyBreakdown } from "../utils";
 import { SUMMARY_COLORS } from "../constants";
 
 interface EntriesSummaryProps {
@@ -27,6 +27,13 @@ export const EntriesSummary = ({
       return null;
     }
     return getWeekSummary(weekEntries);
+  }, [weekEntries]);
+
+  const dailyBreakdown = useMemo(() => {
+    if (!weekEntries || !Array.isArray(weekEntries)) {
+      return [];
+    }
+    return getDailyBreakdown(weekEntries);
   }, [weekEntries]);
 
   const shouldShowSummary =
@@ -69,6 +76,14 @@ export const EntriesSummary = ({
           }
         />
       )}
+      {dailyBreakdown.map((row) => (
+        <List.Item
+          key={row.date}
+          title={`${row.dayLabel} ${row.date}`}
+          subtitle={row.totalFormatted}
+          icon={Icon.Calendar}
+        />
+      ))}
       {summary && summary.exists && (
         <List.Item
           title={summary.title}

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -8,6 +8,7 @@ import {
 } from "@raycast/api";
 import { DailyBreakdownRowType } from "../types";
 import { SUMMARY_COLORS } from "../constants";
+import { dateOnTimezone } from "../utils";
 
 interface WeekDailyBreakdownProps {
   rows: DailyBreakdownRowType[];
@@ -15,7 +16,7 @@ interface WeekDailyBreakdownProps {
 
 export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
   const { pop } = useNavigation();
-  const today = new Date().toISOString().split("T")[0];
+  const today = dateOnTimezone(new Date());
 
   return (
     <List navigationTitle="Weekly Breakdown">

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -1,4 +1,4 @@
-import { List, Icon } from "@raycast/api";
+import { List, ActionPanel, Action, Icon, useNavigation } from "@raycast/api";
 import { DailyBreakdownRowType } from "../types";
 import { SUMMARY_COLORS } from "../constants";
 
@@ -7,6 +7,8 @@ interface WeekDailyBreakdownProps {
 }
 
 export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
+  const { pop } = useNavigation();
+
   return (
     <List navigationTitle="Weekly Breakdown">
       <List.Section title="Daily Breakdown">
@@ -25,6 +27,16 @@ export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
                 text: row.unbillable,
               },
             ]}
+            actions={
+              <ActionPanel>
+                <Action
+                  title="Back"
+                  icon={Icon.ArrowLeft}
+                  onAction={pop}
+                  shortcut={{ modifiers: ["cmd"], key: "[" }}
+                />
+              </ActionPanel>
+            }
           />
         ))}
       </List.Section>

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -16,6 +16,8 @@ interface WeekDailyBreakdownProps {
 
 export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
   const { pop } = useNavigation();
+  // Noko entry dates are date-only strings; useWeekEntries fetches them with
+  // dateOnTimezone bounds, so compare against the same timezone-adjusted today.
   const today = dateOnTimezone(new Date());
 
   return (

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -1,0 +1,33 @@
+import { List, Icon } from "@raycast/api";
+import { DailyBreakdownRowType } from "../types";
+import { SUMMARY_COLORS } from "../constants";
+
+interface WeekDailyBreakdownProps {
+  rows: DailyBreakdownRowType[];
+}
+
+export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
+  return (
+    <List navigationTitle="Weekly Breakdown">
+      <List.Section title="Daily Breakdown">
+        {rows.map((row) => (
+          <List.Item
+            key={row.date}
+            title={`${row.dayLabel} ${row.date}   ${row.totalFormatted}`}
+            icon={Icon.Calendar}
+            accessories={[
+              {
+                icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
+                text: row.billable,
+              },
+              {
+                icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
+                text: row.unbillable,
+              },
+            ]}
+          />
+        ))}
+      </List.Section>
+    </List>
+  );
+};

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -1,10 +1,12 @@
-import { List, ActionPanel, Action, Icon, useNavigation } from "@raycast/api";
+import { List, ActionPanel, Action, Icon, Color, useNavigation } from "@raycast/api";
 import { DailyBreakdownRowType } from "../types";
 import { SUMMARY_COLORS } from "../constants";
 
 interface WeekDailyBreakdownProps {
   rows: DailyBreakdownRowType[];
 }
+
+const today = new Date().toISOString().split("T")[0];
 
 export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
   const { pop } = useNavigation();
@@ -18,6 +20,7 @@ export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
             title={`${row.dayLabel} ${row.date}   ${row.totalFormatted}`}
             icon={Icon.Calendar}
             accessories={[
+              ...(row.date === today ? [{ tag: { value: "Today", color: Color.Green } }] : []),
               {
                 icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
                 text: row.billable,

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -1,4 +1,11 @@
-import { List, ActionPanel, Action, Icon, Color, useNavigation } from "@raycast/api";
+import {
+  List,
+  ActionPanel,
+  Action,
+  Icon,
+  Color,
+  useNavigation,
+} from "@raycast/api";
 import { DailyBreakdownRowType } from "../types";
 import { SUMMARY_COLORS } from "../constants";
 
@@ -20,13 +27,21 @@ export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
             title={`${row.dayLabel} ${row.date}   ${row.totalFormatted}`}
             icon={Icon.Calendar}
             accessories={[
-              ...(row.date === today ? [{ tag: { value: "Today", color: Color.Green } }] : []),
+              ...(row.date === today
+                ? [{ tag: { value: "Today", color: Color.Green } }]
+                : []),
               {
-                icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.BILLABLE },
+                icon: {
+                  source: Icon.Coins,
+                  tintColor: SUMMARY_COLORS.BILLABLE,
+                },
                 text: row.billable,
               },
               {
-                icon: { source: Icon.Coins, tintColor: SUMMARY_COLORS.UNBILLABLE },
+                icon: {
+                  source: Icon.Coins,
+                  tintColor: SUMMARY_COLORS.UNBILLABLE,
+                },
                 text: row.unbillable,
               },
             ]}

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -13,10 +13,9 @@ interface WeekDailyBreakdownProps {
   rows: DailyBreakdownRowType[];
 }
 
-const today = new Date().toISOString().split("T")[0];
-
 export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
   const { pop } = useNavigation();
+  const today = new Date().toISOString().split("T")[0];
 
   return (
     <List navigationTitle="Weekly Breakdown">

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,8 @@ type DailyBreakdownRowType = {
   date: string;
   dayLabel: string;
   totalFormatted: string;
+  billable: string;
+  unbillable: string;
   minutes: number;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,13 @@ type EditEntryPayload = {
   projectId: string;
 };
 
+type DailyBreakdownRowType = {
+  date: string;
+  dayLabel: string;
+  totalFormatted: string;
+  minutes: number;
+};
+
 // Component prop types
 type ViewType = "timers" | "add-entry" | "edit-entry" | "entries";
 
@@ -166,5 +173,6 @@ export type {
   EditEntryPayload,
   EntriesSummaryType,
   WeekSummaryType,
+  DailyBreakdownRowType,
   ViewType,
 };

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -98,7 +98,7 @@ export const getDailyBreakdown = (
 
   return Object.entries(byDate)
     .map(([date, { total, billable }]) => {
-      const dayIndex = new Date(date.replace(/-/g, "/")).getDay();
+      const dayIndex = new Date(`${date}T00:00:00Z`).getUTCDay();
       const unbillableMinutes = total - billable;
       return {
         date,

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -1,4 +1,9 @@
-import { EntryType, EntriesSummaryType, WeekSummaryType } from "../types";
+import {
+  EntryType,
+  EntriesSummaryType,
+  WeekSummaryType,
+  DailyBreakdownRowType,
+} from "../types";
 import { hoursFormat } from "./time-utils";
 
 export const calculateEntrySummary = (entries: EntryType[]) => {
@@ -72,6 +77,31 @@ export const getEntriesSummary = (entries: EntryType[]): EntriesSummaryType => {
     billable: summary.billableFormatted,
     unbillable: summary.unbillableFormatted,
   };
+};
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export const getDailyBreakdown = (
+  entries: EntryType[],
+): DailyBreakdownRowType[] => {
+  const minutesByDate: Record<string, number> = {};
+
+  for (const entry of entries) {
+    minutesByDate[entry.date] =
+      (minutesByDate[entry.date] ?? 0) + entry.minutes;
+  }
+
+  return Object.entries(minutesByDate)
+    .map(([date, minutes]) => {
+      const dayIndex = new Date(date.replace(/-/g, "/")).getDay();
+      return {
+        date,
+        dayLabel: DAY_LABELS[dayIndex],
+        totalFormatted: hoursFormat(minutes),
+        minutes,
+      };
+    })
+    .sort((a, b) => a.date.localeCompare(b.date));
 };
 
 export const getWeekSummary = (entries: EntryType[]): WeekSummaryType => {

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -84,21 +84,29 @@ const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 export const getDailyBreakdown = (
   entries: EntryType[],
 ): DailyBreakdownRowType[] => {
-  const minutesByDate: Record<string, number> = {};
+  const byDate: Record<string, { total: number; billable: number }> = {};
 
   for (const entry of entries) {
-    minutesByDate[entry.date] =
-      (minutesByDate[entry.date] ?? 0) + entry.minutes;
+    if (!byDate[entry.date]) {
+      byDate[entry.date] = { total: 0, billable: 0 };
+    }
+    byDate[entry.date].total += entry.minutes;
+    if (entry.billable) {
+      byDate[entry.date].billable += entry.minutes;
+    }
   }
 
-  return Object.entries(minutesByDate)
-    .map(([date, minutes]) => {
+  return Object.entries(byDate)
+    .map(([date, { total, billable }]) => {
       const dayIndex = new Date(date.replace(/-/g, "/")).getDay();
+      const unbillableMinutes = total - billable;
       return {
         date,
         dayLabel: DAY_LABELS[dayIndex],
-        totalFormatted: hoursFormat(minutes),
-        minutes,
+        totalFormatted: hoursFormat(total),
+        billable: hoursFormat(billable),
+        unbillable: hoursFormat(unbillableMinutes),
+        minutes: total,
       };
     })
     .sort((a, b) => a.date.localeCompare(b.date));

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -64,6 +64,7 @@ export const EntriesView = ({
       }
       isLoading={isLoading}
       isShowingDetail={isShowingDetail}
+      selectedItemId="summary-today"
       actions={
         <ActionPanel>
           {onAddEntry && (

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -64,7 +64,9 @@ export const EntriesView = ({
       }
       isLoading={isLoading}
       isShowingDetail={isShowingDetail}
-      selectedItemId={filteredEntries?.length ? "summary-today" : "summary-week"}
+      selectedItemId={
+        filteredEntries?.length ? "summary-today" : "summary-week"
+      }
       actions={
         <ActionPanel>
           {onAddEntry && (

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -64,7 +64,7 @@ export const EntriesView = ({
       }
       isLoading={isLoading}
       isShowingDetail={isShowingDetail}
-      selectedItemId="summary-today"
+      selectedItemId={filteredEntries?.length ? "summary-today" : "summary-week"}
       actions={
         <ActionPanel>
           {onAddEntry && (


### PR DESCRIPTION
## Summary

- Adds per-day rows below the week total in the entries summary section
- Each row shows the day label (Mon, Tue...), date, and total hours for that day
- Derives data from `weekEntries` already fetched; no additional API call needed

## Changes

- `entry-utils.ts`: new `getDailyBreakdown` function groups week entries by date
- `types.ts`: new `DailyBreakdownRowType`
- `EntriesSummary.tsx`: renders daily rows after the week total row

## Test plan

- [ ] Open entries view — daily rows appear below the week total (one per day logged this week)
- [ ] Days with no entries are not shown
- [ ] Rows are sorted chronologically
- [ ] Unit tests in `getDailyBreakdown.test.ts` cover grouping, formatting, sorting, and day labels