### PR TITLE
feat(entries): add weekly time goal indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,14 @@
           "value": "Australia/Sydney"
         }
       ]
+    },
+    {
+      "name": "weeklyGoalHours",
+      "type": "textfield",
+      "required": false,
+      "title": "Weekly Hour Goal",
+      "description": "Target number of hours to log per week. Leave blank to disable the goal indicator.",
+      "placeholder": "40"
     }
   ],
   "dependencies": {

--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -1,4 +1,5 @@
 import { EntryType } from "../types";
+import { SUMMARY_COLORS } from "../constants";
 
 const makeEntry = (overrides: Partial<EntryType> = {}): EntryType => ({
   id: "1",
@@ -57,5 +58,29 @@ describe("EntryItem copy description action", () => {
     const shortcut = { modifiers: ["cmd"] as const, key: "c" };
     expect(shortcut.modifiers).toContain("cmd");
     expect(shortcut.key).toBe("c");
+  });
+});
+
+// Mirrors the billable coin tint used in the today-entry accessory
+const billableTint = (entry: EntryType): string =>
+  entry.billable ? SUMMARY_COLORS.BILLABLE : SUMMARY_COLORS.UNBILLABLE;
+
+describe("EntryItem time accessory", () => {
+  it("tints the coin green for billable entries", () => {
+    expect(billableTint(makeEntry({ billable: true }))).toBe(
+      SUMMARY_COLORS.BILLABLE,
+    );
+  });
+
+  it("tints the coin red for unbillable entries", () => {
+    expect(billableTint(makeEntry({ billable: false }))).toBe(
+      SUMMARY_COLORS.UNBILLABLE,
+    );
+  });
+
+  it("shows the formatted time as the accessory text", () => {
+    expect(makeEntry({ formatted_minutes: "2:30" }).formatted_minutes).toBe(
+      "2:30",
+    );
   });
 });

--- a/src/__tests__/getDailyBreakdown.test.ts
+++ b/src/__tests__/getDailyBreakdown.test.ts
@@ -74,6 +74,23 @@ describe("getDailyBreakdown", () => {
     expect(result[0].unbillable).toBe("00:30");
   });
 
+  it("counts entries and billable percentage per day", () => {
+    const entries = [
+      makeEntry("2026-05-19", 60, { billable: true }),
+      makeEntry("2026-05-19", 60, { billable: true }),
+      makeEntry("2026-05-19", 60, { billable: false }),
+    ];
+    const result = getDailyBreakdown(entries);
+    expect(result[0].entryCount).toBe(3);
+    expect(result[0].billablePercentage).toBe(67);
+  });
+
+  it("reports 0% billable when day has no billable time", () => {
+    const entries = [makeEntry("2026-05-19", 30, { billable: false })];
+    const result = getDailyBreakdown(entries);
+    expect(result[0].billablePercentage).toBe(0);
+  });
+
   it("sorts rows by date ascending", () => {
     const entries = [
       makeEntry("2026-05-21", 30),

--- a/src/__tests__/weeklyGoal.test.ts
+++ b/src/__tests__/weeklyGoal.test.ts
@@ -23,6 +23,7 @@ const makeEntry = (minutes: number): EntryType => ({
     name: "Project",
     color: "#ff0000",
     enabled: true,
+    billable: true,
   },
 });
 
@@ -65,5 +66,12 @@ describe("getWeeklyGoalProgress", () => {
     const entries = [makeEntry(60), makeEntry(120), makeEntry(60)]; // 4 hours total
     const result = getWeeklyGoalProgress(entries, 8);
     expect(result.percentage).toBe(50);
+  });
+
+  it("returns 0% progress when goalHours is 0", () => {
+    const entries = [makeEntry(60 * 20)];
+    const result = getWeeklyGoalProgress(entries, 0);
+    expect(result.percentage).toBe(0);
+    expect(result.met).toBe(true); // 0 goal means any logged time meets it
   });
 });

--- a/src/__tests__/weeklyGoal.test.ts
+++ b/src/__tests__/weeklyGoal.test.ts
@@ -74,4 +74,34 @@ describe("getWeeklyGoalProgress", () => {
     expect(result.percentage).toBe(0);
     expect(result.met).toBe(true); // 0 goal means any logged time meets it
   });
+
+  describe("pace status", () => {
+    it("is met when the whole goal is reached", () => {
+      const result = getWeeklyGoalProgress([makeEntry(60 * 40)], 40, 3);
+      expect(result.status).toBe("met");
+    });
+
+    it("is on-track when logged meets the expected pace so far", () => {
+      // Wed (3 of 5 weekdays) of a 40h goal expects 24h; logged 24h.
+      const result = getWeeklyGoalProgress([makeEntry(60 * 24)], 40, 3);
+      expect(result.status).toBe("on-track");
+    });
+
+    it("is behind when logged is under pace but within 75%", () => {
+      // Wed expects 24h; 20h is 83% of expected → behind.
+      const result = getWeeklyGoalProgress([makeEntry(60 * 20)], 40, 3);
+      expect(result.status).toBe("behind");
+    });
+
+    it("is at-risk when far under the expected pace", () => {
+      // Mon expects 8h; only 2h logged → at risk.
+      const result = getWeeklyGoalProgress([makeEntry(60 * 2)], 40, 1);
+      expect(result.status).toBe("at-risk");
+    });
+
+    it("is on-track on Sunday before any working day elapses", () => {
+      const result = getWeeklyGoalProgress([], 40, 0);
+      expect(result.status).toBe("on-track");
+    });
+  });
 });

--- a/src/__tests__/weeklyGoal.test.ts
+++ b/src/__tests__/weeklyGoal.test.ts
@@ -1,0 +1,69 @@
+import { getWeeklyGoalProgress } from "../utils/entry-utils";
+import { EntryType } from "../types";
+
+const makeEntry = (minutes: number): EntryType => ({
+  id: String(minutes),
+  date: "2026-05-19",
+  billable: true,
+  minutes,
+  formatted_minutes: "",
+  description: "",
+  approved_by: null,
+  approved_at: "",
+  user: {
+    id: "u1",
+    email: "user@example.com",
+    first_name: "Jane",
+    last_name: "Doe",
+    profile_image_url: "",
+  },
+  tags: [],
+  project: {
+    id: "p1",
+    name: "Project",
+    color: "#ff0000",
+    enabled: true,
+  },
+});
+
+describe("getWeeklyGoalProgress", () => {
+  it("returns 0% progress with no entries", () => {
+    const result = getWeeklyGoalProgress([], 40);
+    expect(result.percentage).toBe(0);
+    expect(result.met).toBe(false);
+  });
+
+  it("calculates correct percentage for partial week", () => {
+    const entries = [makeEntry(60 * 20)]; // 20 hours out of 40 goal
+    const result = getWeeklyGoalProgress(entries, 40);
+    expect(result.percentage).toBe(50);
+    expect(result.met).toBe(false);
+  });
+
+  it("marks goal as met when total reaches goal", () => {
+    const entries = [makeEntry(60 * 40)]; // exactly 40 hours
+    const result = getWeeklyGoalProgress(entries, 40);
+    expect(result.percentage).toBe(100);
+    expect(result.met).toBe(true);
+  });
+
+  it("caps percentage at 100 when over goal", () => {
+    const entries = [makeEntry(60 * 50)]; // 50 hours, over 40 goal
+    const result = getWeeklyGoalProgress(entries, 40);
+    expect(result.percentage).toBe(100);
+    expect(result.met).toBe(true);
+  });
+
+  it("returns formatted logged and goal strings", () => {
+    const entries = [makeEntry(90)]; // 1h30m
+    const result = getWeeklyGoalProgress(entries, 40);
+    expect(result.logged).toBe("01:30");
+    expect(result.goal).toBe("40:00");
+  });
+
+  it("sums all entries for total minutes", () => {
+    const entries = [makeEntry(60), makeEntry(120), makeEntry(60)]; // 4 hours total
+    const result = getWeeklyGoalProgress(entries, 8);
+    expect(result.percentage).toBe(50);
+  });
+});

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -57,7 +57,14 @@ export const EntriesSummary = ({
     if (!effectiveGoalHours || !weekEntries || !Array.isArray(weekEntries)) {
       return null;
     }
-    return getWeeklyGoalProgress(weekEntries, effectiveGoalHours);
+    // Mon=1..Fri=5; Sat(6) and Sun(0) clamp to a full/empty work week so the
+    // weekend never reads as "behind" once the working days are over.
+    const workingDaysElapsed = Math.min(new Date().getDay(), 5);
+    return getWeeklyGoalProgress(
+      weekEntries,
+      effectiveGoalHours,
+      workingDaysElapsed,
+    );
   }, [weekEntries, effectiveGoalHours]);
 
   const shouldShowSummary =

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -69,18 +69,6 @@ export const EntriesSummary = ({
 
   return (
     <List.Section title="Summary">
-      {goalProgress && (
-        <List.Item
-          title={`Goal: ${goalProgress.logged} / ${goalProgress.goal}`}
-          subtitle={`${goalProgress.percentage}% complete`}
-          icon={{
-            source: goalProgress.met ? Icon.CheckCircle : Icon.Clock,
-            tintColor: goalProgress.met
-              ? SUMMARY_COLORS.BILLABLE
-              : SUMMARY_COLORS.UNBILLABLE,
-          }}
-        />
-      )}
       {summary && summary.exists && (
         <List.Item
           id="summary-today"
@@ -136,7 +124,12 @@ export const EntriesSummary = ({
               <Action.Push
                 title="View Daily Breakdown"
                 icon={Icon.Calendar}
-                target={<WeekDailyBreakdown rows={dailyBreakdown} />}
+                target={
+                  <WeekDailyBreakdown
+                    rows={dailyBreakdown}
+                    goalProgress={goalProgress}
+                  />
+                }
               />
             </ActionPanel>
           }

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -1,7 +1,18 @@
-import { List, ActionPanel, Action, Icon } from "@raycast/api";
+import {
+  List,
+  ActionPanel,
+  Action,
+  Icon,
+  getPreferenceValues,
+} from "@raycast/api";
 import { useMemo } from "react";
-import { EntryType } from "../types";
-import { getEntriesSummary, getWeekSummary, getDailyBreakdown } from "../utils";
+import { EntryType, IPreferences } from "../types";
+import {
+  getEntriesSummary,
+  getWeekSummary,
+  getDailyBreakdown,
+  getWeeklyGoalProgress,
+} from "../utils";
 import { SUMMARY_COLORS } from "../constants";
 import { WeekDailyBreakdown } from "./WeekDailyBreakdown";
 
@@ -16,6 +27,9 @@ export const EntriesSummary = ({
   weekEntries,
   onCancel,
 }: EntriesSummaryProps) => {
+  const { weeklyGoalHours } = getPreferenceValues<IPreferences>();
+  const goalHours = weeklyGoalHours ? parseFloat(weeklyGoalHours) : null;
+
   const summary = useMemo(() => {
     if (!entries || !Array.isArray(entries)) {
       return null;
@@ -37,6 +51,13 @@ export const EntriesSummary = ({
     return getDailyBreakdown(weekEntries);
   }, [weekEntries]);
 
+  const goalProgress = useMemo(() => {
+    if (!goalHours || !weekEntries || !Array.isArray(weekEntries)) {
+      return null;
+    }
+    return getWeeklyGoalProgress(weekEntries, goalHours);
+  }, [weekEntries, goalHours]);
+
   const shouldShowSummary =
     (summary && summary.exists) || (weekSummary && weekSummary.exists);
 
@@ -46,6 +67,18 @@ export const EntriesSummary = ({
 
   return (
     <List.Section title="Summary">
+      {goalProgress && (
+        <List.Item
+          title={`Goal: ${goalProgress.logged} / ${goalProgress.goal}`}
+          subtitle={`${goalProgress.percentage}% complete`}
+          icon={{
+            source: goalProgress.met ? Icon.CheckCircle : Icon.Clock,
+            tintColor: goalProgress.met
+              ? SUMMARY_COLORS.BILLABLE
+              : SUMMARY_COLORS.UNBILLABLE,
+          }}
+        />
+      )}
       {summary && summary.exists && (
         <List.Item
           id="summary-today"

--- a/src/components/EntriesSummary.tsx
+++ b/src/components/EntriesSummary.tsx
@@ -29,6 +29,8 @@ export const EntriesSummary = ({
 }: EntriesSummaryProps) => {
   const { weeklyGoalHours } = getPreferenceValues<IPreferences>();
   const goalHours = weeklyGoalHours ? parseFloat(weeklyGoalHours) : null;
+  const effectiveGoalHours =
+    goalHours !== null && goalHours > 0 ? goalHours : null;
 
   const summary = useMemo(() => {
     if (!entries || !Array.isArray(entries)) {
@@ -52,11 +54,11 @@ export const EntriesSummary = ({
   }, [weekEntries]);
 
   const goalProgress = useMemo(() => {
-    if (!goalHours || !weekEntries || !Array.isArray(weekEntries)) {
+    if (!effectiveGoalHours || !weekEntries || !Array.isArray(weekEntries)) {
       return null;
     }
-    return getWeeklyGoalProgress(weekEntries, goalHours);
-  }, [weekEntries, goalHours]);
+    return getWeeklyGoalProgress(weekEntries, effectiveGoalHours);
+  }, [weekEntries, effectiveGoalHours]);
 
   const shouldShowSummary =
     (summary && summary.exists) || (weekSummary && weekSummary.exists);

--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -119,7 +119,6 @@ export const EntryItem = memo<EntryItemProps>(
       <List.Item
         key={entry.id}
         title={entry.project.name}
-        subtitle={entry.description}
         icon={{
           source: Icon.CircleFilled,
           tintColor: entry.project.color,

--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo, useCallback } from "react";
 import { EntryType } from "../types";
 import { userName, formatTags } from "../utils";
 import { useEntryActions } from "../hooks";
+import { SUMMARY_COLORS } from "../constants";
 
 interface EntryItemProps {
   entry: EntryType;
@@ -118,11 +119,22 @@ export const EntryItem = memo<EntryItemProps>(
       <List.Item
         key={entry.id}
         title={entry.project.name}
-        subtitle={entry.formatted_minutes}
+        subtitle={entry.description}
         icon={{
           source: Icon.CircleFilled,
           tintColor: entry.project.color,
         }}
+        accessories={[
+          {
+            icon: {
+              source: Icon.Coins,
+              tintColor: entry.billable
+                ? SUMMARY_COLORS.BILLABLE
+                : SUMMARY_COLORS.UNBILLABLE,
+            },
+            text: entry.formatted_minutes,
+          },
+        ]}
         detail={<List.Item.Detail metadata={detailMetadata} />}
         actions={
           <ActionPanel>

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -6,27 +6,60 @@ import {
   Color,
   useNavigation,
 } from "@raycast/api";
-import { DailyBreakdownRowType } from "../types";
+import { DailyBreakdownRowType, GoalProgressType } from "../types";
 import { SUMMARY_COLORS } from "../constants";
 import { dateOnTimezone } from "../utils";
 
 interface WeekDailyBreakdownProps {
   rows: DailyBreakdownRowType[];
+  goalProgress?: GoalProgressType | null;
 }
 
-export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
+export const WeekDailyBreakdown = ({
+  rows,
+  goalProgress,
+}: WeekDailyBreakdownProps) => {
   const { pop } = useNavigation();
   // Noko entry dates are date-only strings; useWeekEntries fetches them with
   // dateOnTimezone bounds, so compare against the same timezone-adjusted today.
   const today = dateOnTimezone(new Date());
 
+  const backAction = (
+    <ActionPanel>
+      <Action
+        title="Back"
+        icon={Icon.ArrowLeft}
+        onAction={pop}
+        shortcut={{ modifiers: ["cmd"], key: "[" }}
+      />
+    </ActionPanel>
+  );
+
   return (
     <List navigationTitle="Weekly Breakdown">
+      {goalProgress && (
+        <List.Section title="Weekly Goal">
+          <List.Item
+            title={`Goal: ${goalProgress.logged} / ${goalProgress.goal}`}
+            subtitle={`${goalProgress.percentage}% complete`}
+            icon={{
+              source: goalProgress.met ? Icon.CheckCircle : Icon.Clock,
+              tintColor: goalProgress.met
+                ? SUMMARY_COLORS.BILLABLE
+                : SUMMARY_COLORS.UNBILLABLE,
+            }}
+            actions={backAction}
+          />
+        </List.Section>
+      )}
       <List.Section title="Daily Breakdown">
         {rows.map((row) => (
           <List.Item
             key={row.date}
             title={`${row.dayLabel} ${row.date}   ${row.totalFormatted}`}
+            subtitle={`${row.entryCount} ${
+              row.entryCount === 1 ? "entry" : "entries"
+            } • ${row.billablePercentage}% billable`}
             icon={Icon.Calendar}
             accessories={[
               ...(row.date === today
@@ -47,16 +80,7 @@ export const WeekDailyBreakdown = ({ rows }: WeekDailyBreakdownProps) => {
                 text: row.unbillable,
               },
             ]}
-            actions={
-              <ActionPanel>
-                <Action
-                  title="Back"
-                  icon={Icon.ArrowLeft}
-                  onAction={pop}
-                  shortcut={{ modifiers: ["cmd"], key: "[" }}
-                />
-              </ActionPanel>
-            }
+            actions={backAction}
           />
         ))}
       </List.Section>

--- a/src/components/WeekDailyBreakdown.tsx
+++ b/src/components/WeekDailyBreakdown.tsx
@@ -15,6 +15,18 @@ interface WeekDailyBreakdownProps {
   goalProgress?: GoalProgressType | null;
 }
 
+// Goal icon reflects pace, not just completion: green when met or on track,
+// yellow when behind but catchable, red when at risk for the week.
+const GOAL_PACE_ICON: Record<
+  GoalProgressType["status"],
+  { source: Icon; tintColor: Color }
+> = {
+  met: { source: Icon.CheckCircle, tintColor: Color.Green },
+  "on-track": { source: Icon.Clock, tintColor: Color.Green },
+  behind: { source: Icon.Clock, tintColor: Color.Yellow },
+  "at-risk": { source: Icon.Clock, tintColor: Color.Red },
+};
+
 export const WeekDailyBreakdown = ({
   rows,
   goalProgress,
@@ -42,12 +54,7 @@ export const WeekDailyBreakdown = ({
           <List.Item
             title={`Goal: ${goalProgress.logged} / ${goalProgress.goal}`}
             subtitle={`${goalProgress.percentage}% complete`}
-            icon={{
-              source: goalProgress.met ? Icon.CheckCircle : Icon.Clock,
-              tintColor: goalProgress.met
-                ? SUMMARY_COLORS.BILLABLE
-                : SUMMARY_COLORS.UNBILLABLE,
-            }}
+            icon={GOAL_PACE_ICON[goalProgress.status]}
             actions={backAction}
           />
         </List.Section>

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@
 interface IPreferences {
   personalAccessToken: string;
   timezone?: string;
+  weeklyGoalHours?: string;
 }
 
 // ============================================================================

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,11 +156,14 @@ type DailyBreakdownRowType = {
   billablePercentage: number;
 };
 
+type GoalPaceStatus = "met" | "on-track" | "behind" | "at-risk";
+
 type GoalProgressType = {
   logged: string;
   goal: string;
   percentage: number;
   met: boolean;
+  status: GoalPaceStatus;
 };
 
 // Component prop types

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,15 @@ type DailyBreakdownRowType = {
   billable: string;
   unbillable: string;
   minutes: number;
+  entryCount: number;
+  billablePercentage: number;
+};
+
+type GoalProgressType = {
+  logged: string;
+  goal: string;
+  percentage: number;
+  met: boolean;
 };
 
 // Component prop types
@@ -177,5 +186,6 @@ export type {
   EntriesSummaryType,
   WeekSummaryType,
   DailyBreakdownRowType,
+  GoalProgressType,
   ViewType,
 };

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -3,6 +3,7 @@ import {
   EntriesSummaryType,
   WeekSummaryType,
   DailyBreakdownRowType,
+  GoalProgressType,
 } from "../types";
 import { hoursFormat } from "./time-utils";
 
@@ -84,22 +85,28 @@ const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 export const getDailyBreakdown = (
   entries: EntryType[],
 ): DailyBreakdownRowType[] => {
-  const byDate: Record<string, { total: number; billable: number }> = {};
+  const byDate: Record<
+    string,
+    { total: number; billable: number; count: number }
+  > = {};
 
   for (const entry of entries) {
     if (!byDate[entry.date]) {
-      byDate[entry.date] = { total: 0, billable: 0 };
+      byDate[entry.date] = { total: 0, billable: 0, count: 0 };
     }
     byDate[entry.date].total += entry.minutes;
+    byDate[entry.date].count += 1;
     if (entry.billable) {
       byDate[entry.date].billable += entry.minutes;
     }
   }
 
   return Object.entries(byDate)
-    .map(([date, { total, billable }]) => {
+    .map(([date, { total, billable, count }]) => {
       const dayIndex = new Date(`${date}T00:00:00Z`).getUTCDay();
       const unbillableMinutes = total - billable;
+      const billablePercentage =
+        total > 0 ? Math.round((billable / total) * 100) : 0;
       return {
         date,
         dayLabel: DAY_LABELS[dayIndex],
@@ -107,6 +114,8 @@ export const getDailyBreakdown = (
         billable: hoursFormat(billable),
         unbillable: hoursFormat(unbillableMinutes),
         minutes: total,
+        entryCount: count,
+        billablePercentage,
       };
     })
     .sort((a, b) => a.date.localeCompare(b.date));
@@ -115,7 +124,7 @@ export const getDailyBreakdown = (
 export const getWeeklyGoalProgress = (
   weekEntries: EntryType[],
   goalHours: number,
-): { logged: string; goal: string; percentage: number; met: boolean } => {
+): GoalProgressType => {
   const totalMinutes = weekEntries.reduce((sum, e) => sum + e.minutes, 0);
   const goalMinutes = goalHours * 60;
   const percentage =

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -121,9 +121,15 @@ export const getDailyBreakdown = (
     .sort((a, b) => a.date.localeCompare(b.date));
 };
 
+// Goal pace assumes a 5-day (Mon–Fri) working week. A day counts as "behind"
+// only once the logged time drops under this fraction of the expected pace.
+const WORKING_DAYS_PER_WEEK = 5;
+const BEHIND_THRESHOLD = 0.75;
+
 export const getWeeklyGoalProgress = (
   weekEntries: EntryType[],
   goalHours: number,
+  workingDaysElapsed = WORKING_DAYS_PER_WEEK,
 ): GoalProgressType => {
   const totalMinutes = weekEntries.reduce((sum, e) => sum + e.minutes, 0);
   const goalMinutes = goalHours * 60;
@@ -131,11 +137,27 @@ export const getWeeklyGoalProgress = (
     goalMinutes > 0
       ? Math.min(Math.round((totalMinutes / goalMinutes) * 100), 100)
       : 0;
+  const met = totalMinutes >= goalMinutes;
+
+  const expectedMinutes =
+    goalMinutes * (workingDaysElapsed / WORKING_DAYS_PER_WEEK);
+  let status: GoalProgressType["status"];
+  if (met) {
+    status = "met";
+  } else if (expectedMinutes <= 0 || totalMinutes >= expectedMinutes) {
+    status = "on-track";
+  } else if (totalMinutes >= expectedMinutes * BEHIND_THRESHOLD) {
+    status = "behind";
+  } else {
+    status = "at-risk";
+  }
+
   return {
     logged: hoursFormat(totalMinutes),
     goal: hoursFormat(goalMinutes),
     percentage,
-    met: totalMinutes >= goalMinutes,
+    met,
+    status,
   };
 };
 

--- a/src/utils/entry-utils.ts
+++ b/src/utils/entry-utils.ts
@@ -112,6 +112,24 @@ export const getDailyBreakdown = (
     .sort((a, b) => a.date.localeCompare(b.date));
 };
 
+export const getWeeklyGoalProgress = (
+  weekEntries: EntryType[],
+  goalHours: number,
+): { logged: string; goal: string; percentage: number; met: boolean } => {
+  const totalMinutes = weekEntries.reduce((sum, e) => sum + e.minutes, 0);
+  const goalMinutes = goalHours * 60;
+  const percentage =
+    goalMinutes > 0
+      ? Math.min(Math.round((totalMinutes / goalMinutes) * 100), 100)
+      : 0;
+  return {
+    logged: hoursFormat(totalMinutes),
+    goal: hoursFormat(goalMinutes),
+    percentage,
+    met: totalMinutes >= goalMinutes,
+  };
+};
+
 export const getWeekSummary = (entries: EntryType[]): WeekSummaryType => {
   if (!entries.length) {
     return {


### PR DESCRIPTION
## Summary

- Adds a new "Weekly Hour Goal" preference (optional, e.g. 40)
- When set, a goal progress row appears at the top of the entries summary section
- Shows `logged / goal` and `% complete`; icon turns green when goal is met
- No effect when the preference is not set

## Changes

- `package.json`: new `weeklyGoalHours` preference (optional textfield)
- `types.ts`: added `weeklyGoalHours` to `IPreferences`
- `entry-utils.ts`: new `getWeeklyGoalProgress` function
- `EntriesSummary.tsx`: reads preference and renders goal row

## Test plan

- [ ] Set "Weekly Hour Goal" to 40 in Raycast preferences
- [ ] Open entries view — goal row appears showing logged hours vs. 40h goal
- [ ] When total hours reach 40, icon turns green
- [ ] Leave preference blank — goal row not shown
- [ ] Unit tests in `weeklyGoal.test.ts` cover percentage, capping, and met detection