### PR TITLE
feat(projects): show week time on rows and refine Add Entry flow

### DIFF
--- a/src/__tests__/ProjectItem.test.ts
+++ b/src/__tests__/ProjectItem.test.ts
@@ -68,3 +68,31 @@ describe("ProjectItem entries tag", () => {
     expect(project.entries).toBeUndefined();
   });
 });
+
+// Mirrors the `{project.enabled && (...)}` guard in ProjectItem so archived
+// projects (enabled=false) never expose Start Timer or Add Entry actions.
+// Noko rejects new timers/entries against disabled projects, so the UI must
+// not offer them.
+const canStartTimer = (project: ProjectType): boolean => project.enabled;
+const canAddEntry = (project: ProjectType): boolean => project.enabled;
+const canViewEntries = (): boolean => true;
+
+describe("ProjectItem actions for archived projects", () => {
+  it("hides Start Timer for archived projects", () => {
+    expect(canStartTimer(makeProject({ enabled: false }))).toBe(false);
+  });
+
+  it("hides Add Entry for archived projects", () => {
+    expect(canAddEntry(makeProject({ enabled: false }))).toBe(false);
+  });
+
+  it("still shows View Entries for archived projects", () => {
+    expect(canViewEntries()).toBe(true);
+  });
+
+  it("shows Start Timer and Add Entry for active projects", () => {
+    const active = makeProject({ enabled: true });
+    expect(canStartTimer(active)).toBe(true);
+    expect(canAddEntry(active)).toBe(true);
+  });
+});

--- a/src/__tests__/projectDetailView.test.ts
+++ b/src/__tests__/projectDetailView.test.ts
@@ -1,0 +1,59 @@
+import { EntryType } from "../types";
+
+const makeEntry = (projectId: string, minutes: number): Partial<EntryType> => ({
+  id: `${projectId}-${minutes}`,
+  minutes,
+  project: {
+    id: projectId,
+    name: "Project",
+    color: "#ff0000",
+    enabled: true,
+    billable: true,
+  },
+});
+
+// Mirrors the weekMinutesByProject computation in TimersView
+const buildWeekMinutesByProject = (
+  entries: Partial<EntryType>[],
+): Record<string, number> => {
+  const map: Record<string, number> = {};
+  for (const entry of entries) {
+    if (entry.project && entry.minutes !== undefined) {
+      map[entry.project.id] = (map[entry.project.id] ?? 0) + entry.minutes;
+    }
+  }
+  return map;
+};
+
+describe("project detail view week minutes", () => {
+  it("returns empty map for no entries", () => {
+    expect(buildWeekMinutesByProject([])).toEqual({});
+  });
+
+  it("sums minutes per project", () => {
+    const entries = [
+      makeEntry("p1", 60),
+      makeEntry("p1", 30),
+      makeEntry("p2", 90),
+    ];
+    const result = buildWeekMinutesByProject(entries);
+    expect(result["p1"]).toBe(90);
+    expect(result["p2"]).toBe(90);
+  });
+
+  it("projects with no entries return 0 via nullish coalescing", () => {
+    const result = buildWeekMinutesByProject([]);
+    expect(result["unknown-project"] ?? 0).toBe(0);
+  });
+
+  it("handles multiple projects independently", () => {
+    const entries = [
+      makeEntry("p1", 60),
+      makeEntry("p2", 30),
+      makeEntry("p3", 120),
+    ];
+    const result = buildWeekMinutesByProject(entries);
+    expect(Object.keys(result)).toHaveLength(3);
+    expect(result["p3"]).toBe(120);
+  });
+});

--- a/src/__tests__/projectDetailView.test.ts
+++ b/src/__tests__/projectDetailView.test.ts
@@ -1,8 +1,23 @@
 import { EntryType } from "../types";
+import { buildWeekMinutesByProject } from "../utils/project-utils";
 
-const makeEntry = (projectId: string, minutes: number): Partial<EntryType> => ({
+const makeEntry = (projectId: string, minutes: number): EntryType => ({
   id: `${projectId}-${minutes}`,
+  date: "2026-05-20",
+  billable: true,
   minutes,
+  formatted_minutes: "",
+  description: "",
+  approved_by: null,
+  approved_at: "",
+  user: {
+    id: "u1",
+    email: "user@example.com",
+    first_name: "Jane",
+    last_name: "Doe",
+    profile_image_url: "",
+  },
+  tags: [],
   project: {
     id: projectId,
     name: "Project",
@@ -11,19 +26,6 @@ const makeEntry = (projectId: string, minutes: number): Partial<EntryType> => ({
     billable: true,
   },
 });
-
-// Mirrors the weekMinutesByProject computation in TimersView
-const buildWeekMinutesByProject = (
-  entries: Partial<EntryType>[],
-): Record<string, number> => {
-  const map: Record<string, number> = {};
-  for (const entry of entries) {
-    if (entry.project && entry.minutes !== undefined) {
-      map[entry.project.id] = (map[entry.project.id] ?? 0) + entry.minutes;
-    }
-  }
-  return map;
-};
 
 describe("project detail view week minutes", () => {
   it("returns empty map for no entries", () => {
@@ -55,5 +57,16 @@ describe("project detail view week minutes", () => {
     const result = buildWeekMinutesByProject(entries);
     expect(Object.keys(result)).toHaveLength(3);
     expect(result["p3"]).toBe(120);
+  });
+
+  it("skips entries with null project", () => {
+    const entry = makeEntry("p1", 60);
+    const entryNoProject = {
+      ...entry,
+      project: null as unknown as EntryType["project"],
+    };
+    const result = buildWeekMinutesByProject([entry, entryNoProject]);
+    expect(result["p1"]).toBe(60);
+    expect(Object.keys(result)).toHaveLength(1);
   });
 });

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -7,62 +7,16 @@ import { hoursFormat } from "../utils/time-utils";
 interface ProjectItemProps {
   project: ProjectType;
   weekMinutes?: number;
-  isShowingDetail?: boolean;
-  onToggleDetail?: () => void;
-  onAddEntry: () => void;
+  onAddEntry: (project: ProjectType) => void;
   onViewEntries: () => void;
   onTimerChange?: () => void;
 }
 
 const ProjectItem = memo<ProjectItemProps>(
-  ({
-    project,
-    weekMinutes,
-    isShowingDetail,
-    onToggleDetail,
-    onAddEntry,
-    onViewEntries,
-    onTimerChange,
-  }) => {
+  ({ project, weekMinutes, onAddEntry, onViewEntries, onTimerChange }) => {
     const { startTimer } = useTimerActions({
       onSuccess: onTimerChange,
     });
-
-    const detailMetadata = (
-      <List.Item.Detail.Metadata>
-        <List.Item.Detail.Metadata.Label
-          title="Status"
-          text={project.enabled ? "Active" : "Archived"}
-        />
-        <List.Item.Detail.Metadata.Separator />
-        {project.billing_increment !== undefined &&
-          project.billing_increment > 0 && (
-            <>
-              <List.Item.Detail.Metadata.Label
-                title="Billing Increment"
-                text={`${project.billing_increment} min`}
-              />
-              <List.Item.Detail.Metadata.Separator />
-            </>
-          )}
-        {weekMinutes !== undefined && (
-          <>
-            <List.Item.Detail.Metadata.Label
-              title="This Week"
-              text={
-                weekMinutes > 0 ? hoursFormat(weekMinutes) : "No time logged"
-              }
-            />
-            <List.Item.Detail.Metadata.Separator />
-          </>
-        )}
-        <List.Item.Detail.Metadata.Label
-          title="Color"
-          text={project.color}
-          icon={{ source: Icon.CircleFilled, tintColor: project.color }}
-        />
-      </List.Item.Detail.Metadata>
-    );
 
     return (
       <List.Item
@@ -75,6 +29,15 @@ const ProjectItem = memo<ProjectItemProps>(
           project.billing_increment ? `${project.billing_increment}m` : ""
         }
         accessories={[
+          ...(weekMinutes !== undefined && weekMinutes > 0
+            ? [
+                {
+                  icon: Icon.Clock,
+                  text: hoursFormat(weekMinutes),
+                  tooltip: "This Week",
+                },
+              ]
+            : []),
           ...(project.entries != null
             ? [
                 {
@@ -93,7 +56,6 @@ const ProjectItem = memo<ProjectItemProps>(
                 tooltip: "Not Billable",
               },
         ]}
-        detail={<List.Item.Detail metadata={detailMetadata} />}
         actions={
           <ActionPanel>
             <Action
@@ -101,18 +63,10 @@ const ProjectItem = memo<ProjectItemProps>(
               icon={Icon.Play}
               onAction={() => startTimer(project)}
             />
-            {onToggleDetail && (
-              <Action
-                title={isShowingDetail ? "Hide Details" : "Show Details"}
-                icon={Icon.Sidebar}
-                onAction={onToggleDetail}
-              />
-            )}
             <Action
               title="Add Entry"
               icon={Icon.Plus}
-              onAction={onAddEntry}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
+              onAction={() => onAddEntry(project)}
             />
             <Action
               title="View Entries"

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -56,7 +56,11 @@ const ProjectItem = memo<ProjectItemProps>(
             <List.Item.Detail.Metadata.Separator />
           </>
         )}
-        <List.Item.Detail.Metadata.Label title="Color" text={project.color} />
+        <List.Item.Detail.Metadata.Label
+          title="Color"
+          text={project.color}
+          icon={{ source: Icon.CircleFilled, tintColor: project.color }}
+        />
       </List.Item.Detail.Metadata>
     );
 

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -101,12 +101,6 @@ const ProjectItem = memo<ProjectItemProps>(
               icon={Icon.Play}
               onAction={() => startTimer(project)}
             />
-            <Action
-              title="Add Entry"
-              icon={Icon.Plus}
-              onAction={onAddEntry}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
-            />
             {onToggleDetail && (
               <Action
                 title={isShowingDetail ? "Hide Details" : "Show Details"}
@@ -114,6 +108,12 @@ const ProjectItem = memo<ProjectItemProps>(
                 onAction={onToggleDetail}
               />
             )}
+            <Action
+              title="Add Entry"
+              icon={Icon.Plus}
+              onAction={onAddEntry}
+              shortcut={{ modifiers: ["cmd"], key: "n" }}
+            />
             <Action
               title="View Entries"
               icon={Icon.List}

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -2,19 +2,63 @@ import { Icon, List, ActionPanel, Action } from "@raycast/api";
 import { memo } from "react";
 import { ProjectType } from "../types";
 import { useTimerActions } from "../hooks/useTimerActions";
+import { hoursFormat } from "../utils/time-utils";
 
 interface ProjectItemProps {
   project: ProjectType;
+  weekMinutes?: number;
+  isShowingDetail?: boolean;
+  onToggleDetail?: () => void;
   onAddEntry: () => void;
   onViewEntries: () => void;
   onTimerChange?: () => void;
 }
 
 const ProjectItem = memo<ProjectItemProps>(
-  ({ project, onAddEntry, onViewEntries, onTimerChange }) => {
+  ({
+    project,
+    weekMinutes,
+    isShowingDetail,
+    onToggleDetail,
+    onAddEntry,
+    onViewEntries,
+    onTimerChange,
+  }) => {
     const { startTimer } = useTimerActions({
       onSuccess: onTimerChange,
     });
+
+    const detailMetadata = (
+      <List.Item.Detail.Metadata>
+        <List.Item.Detail.Metadata.Label
+          title="Status"
+          text={project.enabled ? "Active" : "Archived"}
+        />
+        <List.Item.Detail.Metadata.Separator />
+        {project.billing_increment !== undefined &&
+          project.billing_increment > 0 && (
+            <>
+              <List.Item.Detail.Metadata.Label
+                title="Billing Increment"
+                text={`${project.billing_increment} min`}
+              />
+              <List.Item.Detail.Metadata.Separator />
+            </>
+          )}
+        {weekMinutes !== undefined && (
+          <>
+            <List.Item.Detail.Metadata.Label
+              title="This Week"
+              text={
+                weekMinutes > 0 ? hoursFormat(weekMinutes) : "No time logged"
+              }
+            />
+            <List.Item.Detail.Metadata.Separator />
+          </>
+        )}
+        <List.Item.Detail.Metadata.Label title="Color" text={project.color} />
+      </List.Item.Detail.Metadata>
+    );
 
     return (
       <List.Item
@@ -45,6 +89,7 @@ const ProjectItem = memo<ProjectItemProps>(
                 tooltip: "Not Billable",
               },
         ]}
+        detail={<List.Item.Detail metadata={detailMetadata} />}
         actions={
           <ActionPanel>
             <Action
@@ -52,6 +97,14 @@ const ProjectItem = memo<ProjectItemProps>(
               icon={Icon.Play}
               onAction={() => startTimer(project)}
             />
+            {onToggleDetail && (
+              <Action
+                title={isShowingDetail ? "Hide Details" : "Show Details"}
+                icon={Icon.Sidebar}
+                onAction={onToggleDetail}
+                shortcut={{ modifiers: ["cmd"], key: "d" }}
+              />
+            )}
             <Action
               title="Add Entry"
               icon={Icon.Plus}

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -101,6 +101,12 @@ const ProjectItem = memo<ProjectItemProps>(
               icon={Icon.Play}
               onAction={() => startTimer(project)}
             />
+            <Action
+              title="Add Entry"
+              icon={Icon.Plus}
+              onAction={onAddEntry}
+              shortcut={{ modifiers: ["cmd"], key: "n" }}
+            />
             {onToggleDetail && (
               <Action
                 title={isShowingDetail ? "Hide Details" : "Show Details"}
@@ -108,12 +114,6 @@ const ProjectItem = memo<ProjectItemProps>(
                 onAction={onToggleDetail}
               />
             )}
-            <Action
-              title="Add Entry"
-              icon={Icon.Plus}
-              onAction={onAddEntry}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
-            />
             <Action
               title="View Entries"
               icon={Icon.List}

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -106,7 +106,6 @@ const ProjectItem = memo<ProjectItemProps>(
                 title={isShowingDetail ? "Hide Details" : "Show Details"}
                 icon={Icon.Sidebar}
                 onAction={onToggleDetail}
-                shortcut={{ modifiers: ["cmd"], key: "d" }}
               />
             )}
             <Action

--- a/src/components/ProjectItem.tsx
+++ b/src/components/ProjectItem.tsx
@@ -58,16 +58,20 @@ const ProjectItem = memo<ProjectItemProps>(
         ]}
         actions={
           <ActionPanel>
-            <Action
-              title="Start Timer"
-              icon={Icon.Play}
-              onAction={() => startTimer(project)}
-            />
-            <Action
-              title="Add Entry"
-              icon={Icon.Plus}
-              onAction={() => onAddEntry(project)}
-            />
+            {project.enabled && (
+              <>
+                <Action
+                  title="Start Timer"
+                  icon={Icon.Play}
+                  onAction={() => startTimer(project)}
+                />
+                <Action
+                  title="Add Entry"
+                  icon={Icon.Plus}
+                  onAction={() => onAddEntry(project)}
+                />
+              </>
+            )}
             <Action
               title="View Entries"
               icon={Icon.List}

--- a/src/components/TimerItem.tsx
+++ b/src/components/TimerItem.tsx
@@ -15,14 +15,13 @@ import useElapsedTime from "../hooks/useElapsedTime";
 
 interface TimerItemProps {
   timer: TimerType;
-  onAddEntry: () => void;
   onViewEntries: () => void;
   onLogTimer: (project: TimerType["project"]) => void;
   onTimerChange?: () => void;
 }
 
 const TimerItem = memo<TimerItemProps>(
-  ({ timer, onAddEntry, onViewEntries, onLogTimer, onTimerChange }) => {
+  ({ timer, onViewEntries, onLogTimer, onTimerChange }) => {
     const currentProject = timer.project;
 
     const elapsedTime = useElapsedTime(timer);
@@ -146,12 +145,6 @@ const TimerItem = memo<TimerItemProps>(
         actions={
           <ActionPanel>
             {timerActions}
-            <Action
-              title="Add Entry"
-              icon={Icon.Plus}
-              onAction={onAddEntry}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
-            />
             <Action
               title="View Entries"
               icon={Icon.List}

--- a/src/timers.tsx
+++ b/src/timers.tsx
@@ -6,10 +6,20 @@ import { ErrorBoundary } from "./components";
 export default function Command() {
   const [currentView, setCurrentView] = useState<ViewType>("timers");
   const [project, setProject] = useState<ProjectType | null>(null);
+  // Distinguishes "log a running timer" (use elapsed time + logTimer endpoint)
+  // from "preselect a project for a fresh entry" (default time + submitEntry).
+  const [hasRunningTimer, setHasRunningTimer] = useState(false);
   const [editingEntry, setEditingEntry] = useState<EntryType | null>(null);
 
   const handleAddEntry = () => {
     setProject(null);
+    setHasRunningTimer(false);
+    setCurrentView("add-entry");
+  };
+
+  const handleAddEntryForProject = (projectToPreset: ProjectType) => {
+    setProject(projectToPreset);
+    setHasRunningTimer(false);
     setCurrentView("add-entry");
   };
 
@@ -20,6 +30,7 @@ export default function Command() {
   const handleBackToTimers = () => {
     setCurrentView("timers");
     setProject(null);
+    setHasRunningTimer(false);
     setEditingEntry(null);
   };
 
@@ -39,12 +50,14 @@ export default function Command() {
 
   const handleLogTimer = (projectToLog: ProjectType) => {
     setProject(projectToLog);
+    setHasRunningTimer(true);
     setCurrentView("add-entry");
   };
 
   const handleEntrySuccess = () => {
     setCurrentView("timers");
     setProject(null);
+    setHasRunningTimer(false);
   };
 
   if (currentView === "add-entry") {
@@ -52,6 +65,7 @@ export default function Command() {
       <ErrorBoundary>
         <AddEntryView
           project={project}
+          hasRunningTimer={hasRunningTimer}
           onSubmit={handleEntrySuccess}
           onCancel={handleBackToTimers}
         />
@@ -87,6 +101,7 @@ export default function Command() {
     <ErrorBoundary>
       <TimersView
         onNavigateToAddEntry={handleAddEntry}
+        onNavigateToAddEntryForProject={handleAddEntryForProject}
         onNavigateToEntries={handleViewEntries}
         onNavigateToLogTimer={handleLogTimer}
       />

--- a/src/timers.tsx
+++ b/src/timers.tsx
@@ -11,12 +11,6 @@ export default function Command() {
   const [hasRunningTimer, setHasRunningTimer] = useState(false);
   const [editingEntry, setEditingEntry] = useState<EntryType | null>(null);
 
-  const handleAddEntry = () => {
-    setProject(null);
-    setHasRunningTimer(false);
-    setCurrentView("add-entry");
-  };
-
   const handleAddEntryForProject = (projectToPreset: ProjectType) => {
     setProject(projectToPreset);
     setHasRunningTimer(false);
@@ -60,7 +54,7 @@ export default function Command() {
     setHasRunningTimer(false);
   };
 
-  if (currentView === "add-entry") {
+  if (currentView === "add-entry" && project) {
     return (
       <ErrorBoundary>
         <AddEntryView
@@ -90,7 +84,6 @@ export default function Command() {
       <ErrorBoundary>
         <EntriesView
           onCancel={handleBackToTimers}
-          onAddEntry={handleAddEntry}
           onEditEntry={handleEditEntry}
         />
       </ErrorBoundary>
@@ -100,7 +93,6 @@ export default function Command() {
   return (
     <ErrorBoundary>
       <TimersView
-        onNavigateToAddEntry={handleAddEntry}
         onNavigateToAddEntryForProject={handleAddEntryForProject}
         onNavigateToEntries={handleViewEntries}
         onNavigateToLogTimer={handleLogTimer}

--- a/src/timers.tsx
+++ b/src/timers.tsx
@@ -1,91 +1,63 @@
 import { useState } from "react";
-import { ProjectType, EntryType, ViewType } from "./types";
+import { ProjectType, EntryType, EntryDraft } from "./types";
 import { TimersView, EntriesView, AddEntryView, EditEntryView } from "./views";
 import { ErrorBoundary } from "./components";
 
+// Single source of truth for routing + per-screen payload. Encoding the
+// payload alongside the screen name makes invalid combinations (e.g.
+// "edit-entry" without an entry, "add-entry" without a draft) impossible.
+type Screen =
+  | { name: "timers" }
+  | { name: "entries" }
+  | { name: "add-entry"; draft: EntryDraft }
+  | { name: "edit-entry"; entry: EntryType };
+
+const TIMERS_SCREEN: Screen = { name: "timers" };
+
 export default function Command() {
-  const [currentView, setCurrentView] = useState<ViewType>("timers");
-  const [project, setProject] = useState<ProjectType | null>(null);
-  // Distinguishes "log a running timer" (use elapsed time + logTimer endpoint)
-  // from "preselect a project for a fresh entry" (default time + submitEntry).
-  const [hasRunningTimer, setHasRunningTimer] = useState(false);
-  const [editingEntry, setEditingEntry] = useState<EntryType | null>(null);
+  const [screen, setScreen] = useState<Screen>(TIMERS_SCREEN);
 
-  const handleAddEntryForProject = (projectToPreset: ProjectType) => {
-    setProject(projectToPreset);
-    setHasRunningTimer(false);
-    setCurrentView("add-entry");
-  };
+  const openManualEntry = (project: ProjectType) =>
+    setScreen({ name: "add-entry", draft: { mode: "manual", project } });
 
-  const handleViewEntries = () => {
-    setCurrentView("entries");
-  };
+  const openTimerLog = (project: ProjectType) =>
+    setScreen({ name: "add-entry", draft: { mode: "log-timer", project } });
 
-  const handleBackToTimers = () => {
-    setCurrentView("timers");
-    setProject(null);
-    setHasRunningTimer(false);
-    setEditingEntry(null);
-  };
+  const openEntries = () => setScreen({ name: "entries" });
 
-  const handleEditEntry = (entry: EntryType) => {
-    setEditingEntry(entry);
-    setCurrentView("edit-entry");
-  };
+  const openEditEntry = (entry: EntryType) =>
+    setScreen({ name: "edit-entry", entry });
 
-  const handleEditSuccess = () => {
-    setCurrentView("entries");
-    setEditingEntry(null);
-  };
+  const goToTimers = () => setScreen(TIMERS_SCREEN);
 
-  const handleCancelEdit = () => {
-    setCurrentView("entries");
-  };
-
-  const handleLogTimer = (projectToLog: ProjectType) => {
-    setProject(projectToLog);
-    setHasRunningTimer(true);
-    setCurrentView("add-entry");
-  };
-
-  const handleEntrySuccess = () => {
-    setCurrentView("timers");
-    setProject(null);
-    setHasRunningTimer(false);
-  };
-
-  if (currentView === "add-entry" && project) {
+  if (screen.name === "add-entry") {
     return (
       <ErrorBoundary>
         <AddEntryView
-          project={project}
-          hasRunningTimer={hasRunningTimer}
-          onSubmit={handleEntrySuccess}
-          onCancel={handleBackToTimers}
+          draft={screen.draft}
+          onSubmit={goToTimers}
+          onCancel={goToTimers}
         />
       </ErrorBoundary>
     );
   }
 
-  if (currentView === "edit-entry" && editingEntry) {
+  if (screen.name === "edit-entry") {
     return (
       <ErrorBoundary>
         <EditEntryView
-          entry={editingEntry}
-          onSubmit={handleEditSuccess}
-          onCancel={handleCancelEdit}
+          entry={screen.entry}
+          onSubmit={openEntries}
+          onCancel={openEntries}
         />
       </ErrorBoundary>
     );
   }
 
-  if (currentView === "entries") {
+  if (screen.name === "entries") {
     return (
       <ErrorBoundary>
-        <EntriesView
-          onCancel={handleBackToTimers}
-          onEditEntry={handleEditEntry}
-        />
+        <EntriesView onCancel={goToTimers} onEditEntry={openEditEntry} />
       </ErrorBoundary>
     );
   }
@@ -93,9 +65,9 @@ export default function Command() {
   return (
     <ErrorBoundary>
       <TimersView
-        onNavigateToAddEntryForProject={handleAddEntryForProject}
-        onNavigateToEntries={handleViewEntries}
-        onNavigateToLogTimer={handleLogTimer}
+        onAddEntry={openManualEntry}
+        onLogTimer={openTimerLog}
+        onViewEntries={openEntries}
       />
     </ErrorBoundary>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,8 +166,12 @@ type GoalProgressType = {
   status: GoalPaceStatus;
 };
 
-// Component prop types
-type ViewType = "timers" | "add-entry" | "edit-entry" | "entries";
+// Add Entry intent: discriminates between a fresh manual entry (default
+// time, regular submit) and logging a running timer (elapsed time prefill,
+// log-timer endpoint). Both always carry a preselected project.
+type EntryDraft =
+  | { mode: "manual"; project: ProjectType }
+  | { mode: "log-timer"; project: ProjectType };
 
 // ============================================================================
 // EXPORTS
@@ -190,5 +194,5 @@ export type {
   WeekSummaryType,
   DailyBreakdownRowType,
   GoalProgressType,
-  ViewType,
+  EntryDraft,
 };

--- a/src/utils/project-utils.ts
+++ b/src/utils/project-utils.ts
@@ -15,6 +15,18 @@ export const buildLatestUsedByProject = (
   return map;
 };
 
+export const buildWeekMinutesByProject = (
+  entries: EntryType[],
+): Record<string, number> => {
+  const map: Record<string, number> = {};
+  for (const entry of entries) {
+    if (entry.project) {
+      map[entry.project.id] = (map[entry.project.id] ?? 0) + entry.minutes;
+    }
+  }
+  return map;
+};
+
 export const sortProjectsByLatestUsed = (
   projects: ProjectType[],
   latestUsed: Record<string, string>,

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -1,6 +1,6 @@
 import { Form, ActionPanel, Action, Icon } from "@raycast/api";
 import { useMemo, useCallback, useState, useEffect } from "react";
-import { EntryFormData, ProjectType } from "../types";
+import { EntryFormData, EntryDraft } from "../types";
 import { useProjects, useTags, useTimer } from "../hooks/useApiData";
 import { useEntrySubmission, useTimerActions } from "../hooks";
 import { apiClient } from "../lib/api-client";
@@ -14,32 +14,27 @@ import {
 import { TOAST_MESSAGES, TIME_DEFAULTS, FORM_MESSAGES } from "../constants";
 
 type AddEntryViewProps = {
+  draft: EntryDraft;
   onSubmit?: () => void;
   onCancel?: () => void;
-  // Project is always preselected: either from a ProjectItem row or from
-  // the running timer's project via TimerItem's Log Timer action.
-  project: ProjectType;
-  // True only when arriving from a running/paused timer (Log Timer flow).
-  // ProjectItem's Add Entry preselects the project but leaves this false so
-  // the form uses default time and the regular entry-submit path.
-  hasRunningTimer?: boolean;
 };
 
 export const AddEntryView = ({
+  draft,
   onSubmit,
   onCancel,
-  project,
-  hasRunningTimer = false,
 }: AddEntryViewProps) => {
+  const { project } = draft;
+  const isTimerMode = draft.mode === "log-timer";
+
   const { data: projects = [] } = useProjects();
   const { data: tags = [] } = useTags();
-  const isTimerMode = hasRunningTimer;
+  // Only fetch the running timer when we are actually in log-timer mode;
+  // a 404 here would otherwise surface as "Error: Not Found" for manual entries.
   const { data: timer, isLoading: timerLoading } = useTimer(
     isTimerMode ? project.id : null,
   );
-  const { submitEntry } = useEntrySubmission({
-    onSuccess: onSubmit,
-  });
+  const { submitEntry } = useEntrySubmission({ onSuccess: onSubmit });
   const { logTimer } = useTimerActions();
 
   const [minutesValue, setMinutesValue] = useState<string>(
@@ -47,73 +42,78 @@ export const AddEntryView = ({
   );
 
   useEffect(() => {
-    if (isTimerMode && timer && !timerLoading) {
-      const currentTime = new Date();
-      const fetchTime = new Date();
-      const elapsedTime = getElapsedTime(timer, currentTime, fetchTime);
-      const minutes = convertElapsedTimeToMinutes(elapsedTime);
-      setMinutesValue(formatMinutesAsTime(minutes));
-    }
+    if (!isTimerMode || !timer || timerLoading) return;
+    const now = new Date();
+    const elapsed = getElapsedTime(timer, now, now);
+    setMinutesValue(formatMinutesAsTime(convertElapsedTimeToMinutes(elapsed)));
   }, [isTimerMode, timer, timerLoading]);
+
+  const submitTimerLog = useCallback(
+    async (values: EntryFormData) => {
+      const selectedProject = projects.find(
+        (p) => p.name === values.project_name,
+      );
+      const projectChanged =
+        selectedProject && selectedProject.id !== project.id;
+
+      // If the user switched the project on the form, discard the original
+      // timer first and then log the time against the chosen project as a
+      // regular entry.
+      if (projectChanged) {
+        const discarded = await apiClient.delete(
+          `/projects/${project.id}/timer`,
+        );
+        if (!discarded.success) {
+          showErrorToast(
+            TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER,
+            discarded.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR,
+          );
+          return;
+        }
+        await submitEntry(values);
+        return;
+      }
+
+      const ok = await logTimer(project.id, values);
+      if (!ok) return;
+      showSuccessToast(
+        TOAST_MESSAGES.SUCCESS.TIMER_LOGGED,
+        `Timer logged for ${project.name}`,
+      );
+      onSubmit?.();
+    },
+    [project, projects, logTimer, submitEntry, onSubmit],
+  );
 
   const handleSubmit = useCallback(
     async (values: EntryFormData) => {
       try {
         if (isTimerMode) {
-          const selectedProject = projects.find(
-            (p) => p.name === values.project_name,
-          );
-          const projectChanged =
-            selectedProject && selectedProject.id !== project.id;
-
-          if (projectChanged) {
-            const discarded = await apiClient.delete(
-              `/projects/${project.id}/timer`,
-            );
-            if (!discarded.success) {
-              showErrorToast(
-                TOAST_MESSAGES.ERROR.FAILED_TO_LOG_TIMER,
-                discarded.error || TOAST_MESSAGES.ERROR.UNKNOWN_ERROR,
-              );
-              return;
-            }
-            await submitEntry(values);
-          } else {
-            const ok = await logTimer(project.id, values);
-            if (!ok) return;
-            showSuccessToast(
-              TOAST_MESSAGES.SUCCESS.TIMER_LOGGED,
-              `Timer logged for ${project.name}`,
-            );
-            onSubmit?.();
-          }
+          await submitTimerLog(values);
         } else {
           await submitEntry(values);
         }
       } catch (error) {
-        const errorMessage =
+        const message =
           error instanceof Error
             ? error.message
             : TOAST_MESSAGES.ERROR.UNKNOWN_ERROR;
-        showErrorToast(TOAST_MESSAGES.ERROR.INVALID_INPUT, errorMessage);
+        showErrorToast(TOAST_MESSAGES.ERROR.INVALID_INPUT, message);
       }
     },
-    [isTimerMode, project, projects, logTimer, submitEntry, onSubmit],
+    [isTimerMode, submitTimerLog, submitEntry],
   );
 
-  const projectOptions = useMemo(() => {
-    return projects.map((project) => ({
-      title: project.name,
-      value: project.name,
-    }));
-  }, [projects]);
+  const projectOptions = useMemo(
+    () => projects.map((p) => ({ title: p.name, value: p.name })),
+    [projects],
+  );
 
-  const tagOptions = useMemo(() => {
-    return tags.map((tag) => ({
-      title: tag.formatted_name,
-      value: tag.formatted_name,
-    }));
-  }, [tags]);
+  const tagOptions = useMemo(
+    () =>
+      tags.map((t) => ({ title: t.formatted_name, value: t.formatted_name })),
+    [tags],
+  );
 
   return (
     <Form

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -16,7 +16,9 @@ import { TOAST_MESSAGES, TIME_DEFAULTS, FORM_MESSAGES } from "../constants";
 type AddEntryViewProps = {
   onSubmit?: () => void;
   onCancel?: () => void;
-  project: ProjectType | null;
+  // Project is always preselected: either from a ProjectItem row or from
+  // the running timer's project via TimerItem's Log Timer action.
+  project: ProjectType;
   // True only when arriving from a running/paused timer (Log Timer flow).
   // ProjectItem's Add Entry preselects the project but leaves this false so
   // the form uses default time and the regular entry-submit path.
@@ -31,7 +33,7 @@ export const AddEntryView = ({
 }: AddEntryViewProps) => {
   const { data: projects = [] } = useProjects();
   const { data: tags = [] } = useTags();
-  const isTimerMode = project !== null && hasRunningTimer;
+  const isTimerMode = hasRunningTimer;
   const { data: timer, isLoading: timerLoading } = useTimer(
     isTimerMode ? project.id : null,
   );
@@ -132,9 +134,7 @@ export const AddEntryView = ({
       <Form.Dropdown
         id="project_name"
         title="Project"
-        defaultValue={project?.name ?? ""}
-        storeValue={project === null}
-        autoFocus={project === null}
+        defaultValue={project.name}
         info={FORM_MESSAGES.PROJECT.INFO}
       >
         {projectOptions.map((option) => (
@@ -159,7 +159,7 @@ export const AddEntryView = ({
         id="description"
         title="Description"
         placeholder={FORM_MESSAGES.DESCRIPTION.PLACEHOLDER}
-        autoFocus={project !== null}
+        autoFocus
         info={
           isTimerMode
             ? FORM_MESSAGES.DESCRIPTION.INFO_TIMER

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -17,24 +17,28 @@ type AddEntryViewProps = {
   onSubmit?: () => void;
   onCancel?: () => void;
   project: ProjectType | null;
+  // True only when arriving from a running/paused timer (Log Timer flow).
+  // ProjectItem's Add Entry preselects the project but leaves this false so
+  // the form uses default time and the regular entry-submit path.
+  hasRunningTimer?: boolean;
 };
 
 export const AddEntryView = ({
   onSubmit,
   onCancel,
   project,
+  hasRunningTimer = false,
 }: AddEntryViewProps) => {
   const { data: projects = [] } = useProjects();
   const { data: tags = [] } = useTags();
+  const isTimerMode = project !== null && hasRunningTimer;
   const { data: timer, isLoading: timerLoading } = useTimer(
-    project?.id || null,
+    isTimerMode ? project.id : null,
   );
   const { submitEntry } = useEntrySubmission({
     onSuccess: onSubmit,
   });
   const { logTimer } = useTimerActions();
-
-  const isTimerMode = project !== null;
 
   const [minutesValue, setMinutesValue] = useState<string>(
     TIME_DEFAULTS.DEFAULT_TIME_FORMAT,
@@ -129,8 +133,8 @@ export const AddEntryView = ({
         id="project_name"
         title="Project"
         defaultValue={project?.name ?? ""}
-        storeValue={!isTimerMode}
-        autoFocus={!isTimerMode}
+        storeValue={project === null}
+        autoFocus={project === null}
         info={FORM_MESSAGES.PROJECT.INFO}
       >
         {projectOptions.map((option) => (
@@ -155,7 +159,7 @@ export const AddEntryView = ({
         id="description"
         title="Description"
         placeholder={FORM_MESSAGES.DESCRIPTION.PLACEHOLDER}
-        autoFocus={isTimerMode}
+        autoFocus={project !== null}
         info={
           isTimerMode
             ? FORM_MESSAGES.DESCRIPTION.INFO_TIMER

--- a/src/views/AddEntryView.tsx
+++ b/src/views/AddEntryView.tsx
@@ -37,8 +37,13 @@ export const AddEntryView = ({
   const { submitEntry } = useEntrySubmission({ onSuccess: onSubmit });
   const { logTimer } = useTimerActions();
 
-  const [minutesValue, setMinutesValue] = useState<string>(
-    TIME_DEFAULTS.DEFAULT_TIME_FORMAT,
+  // Manual entries default to the project's billing increment from the API
+  // (e.g. 5 or 15 min). Log-timer entries are overwritten by elapsed time
+  // in the effect below once the timer fetch resolves.
+  const [minutesValue, setMinutesValue] = useState<string>(() =>
+    project.billing_increment && project.billing_increment > 0
+      ? formatMinutesAsTime(project.billing_increment)
+      : TIME_DEFAULTS.DEFAULT_TIME_FORMAT,
   );
 
   useEffect(() => {

--- a/src/views/EntriesView.tsx
+++ b/src/views/EntriesView.tsx
@@ -7,15 +7,10 @@ import { UI_MESSAGES } from "../constants";
 
 interface EntriesViewProps {
   onCancel?: () => void;
-  onAddEntry?: () => void;
   onEditEntry?: (entry: EntryType) => void;
 }
 
-export const EntriesView = ({
-  onCancel,
-  onAddEntry,
-  onEditEntry,
-}: EntriesViewProps) => {
+export const EntriesView = ({ onCancel, onEditEntry }: EntriesViewProps) => {
   const { isLoading, filter, filteredEntries, setFilter, error } = useEntries();
   const { data: weekEntries } = useWeekEntries();
   const { isShowingDetail, toggleDetail } = useDetailToggle(false);
@@ -69,14 +64,6 @@ export const EntriesView = ({
       }
       actions={
         <ActionPanel>
-          {onAddEntry && (
-            <Action
-              title="Add Entry"
-              icon={Icon.Plus}
-              onAction={onAddEntry}
-              shortcut={{ modifiers: ["cmd"], key: "n" }}
-            />
-          )}
           {onCancel && (
             <Action
               title="Back"

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -7,7 +7,6 @@ import {
   useTimers,
   useRecentEntries,
   useWeekEntries,
-  useDetailToggle,
 } from "../hooks";
 import {
   buildLatestUsedByProject,
@@ -43,8 +42,6 @@ export const TimersView = ({
     mutate: refreshTimers,
   } = useTimers();
 
-  const { isShowingDetail, toggleDetail } = useDetailToggle(false);
-
   const isLoading = projectsLoading || timersLoading || recentEntriesLoading;
 
   const latestUsedByProject = useMemo(
@@ -74,7 +71,6 @@ export const TimersView = ({
   return (
     <List
       isLoading={isLoading}
-      isShowingDetail={isShowingDetail}
       searchBarAccessory={
         <List.Dropdown
           tooltip="Filter Projects"
@@ -103,9 +99,7 @@ export const TimersView = ({
           key={project.id}
           project={project}
           weekMinutes={weekMinutesByProject[project.id] ?? 0}
-          isShowingDetail={isShowingDetail}
-          onToggleDetail={toggleDetail}
-          onAddEntry={onNavigateToAddEntry}
+          onAddEntry={onNavigateToLogTimer}
           onViewEntries={onNavigateToEntries}
           onTimerChange={refreshTimers}
         />

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -1,6 +1,7 @@
 import { List } from "@raycast/api";
 import { useMemo, useState, useCallback } from "react";
 import { ProjectType } from "../types";
+import { buildWeekMinutesByProject } from "../utils";
 import {
   useProjects,
   useTimers,
@@ -51,13 +52,10 @@ export const TimersView = ({
     [recentEntries],
   );
 
-  const weekMinutesByProject = useMemo(() => {
-    const map: Record<string, number> = {};
-    for (const entry of weekEntries) {
-      map[entry.project.id] = (map[entry.project.id] ?? 0) + entry.minutes;
-    }
-    return map;
-  }, [weekEntries]);
+  const weekMinutesByProject = useMemo(
+    () => buildWeekMinutesByProject(weekEntries),
+    [weekEntries],
+  );
 
   const projectsWithoutTimers = useMemo(() => {
     const projectIdsWithTimers = new Set(

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -1,7 +1,13 @@
 import { List } from "@raycast/api";
 import { useMemo, useState, useCallback } from "react";
 import { ProjectType } from "../types";
-import { useProjects, useTimers, useRecentEntries } from "../hooks";
+import {
+  useProjects,
+  useTimers,
+  useRecentEntries,
+  useWeekEntries,
+  useDetailToggle,
+} from "../hooks";
 import {
   buildLatestUsedByProject,
   sortProjectsByLatestUsed,
@@ -28,6 +34,7 @@ export const TimersView = ({
     useProjects(projectFilter);
   const { data: recentEntries = [], isLoading: recentEntriesLoading } =
     useRecentEntries(30);
+  const { data: weekEntries = [] } = useWeekEntries();
 
   const {
     data: timers = [],
@@ -35,12 +42,22 @@ export const TimersView = ({
     mutate: refreshTimers,
   } = useTimers();
 
+  const { isShowingDetail, toggleDetail } = useDetailToggle(false);
+
   const isLoading = projectsLoading || timersLoading || recentEntriesLoading;
 
   const latestUsedByProject = useMemo(
     () => buildLatestUsedByProject(recentEntries),
     [recentEntries],
   );
+
+  const weekMinutesByProject = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const entry of weekEntries) {
+      map[entry.project.id] = (map[entry.project.id] ?? 0) + entry.minutes;
+    }
+    return map;
+  }, [weekEntries]);
 
   const projectsWithoutTimers = useMemo(() => {
     const projectIdsWithTimers = new Set(
@@ -59,6 +76,7 @@ export const TimersView = ({
   return (
     <List
       isLoading={isLoading}
+      isShowingDetail={isShowingDetail}
       searchBarAccessory={
         <List.Dropdown
           tooltip="Filter Projects"
@@ -86,6 +104,9 @@ export const TimersView = ({
         <ProjectItem
           key={project.id}
           project={project}
+          weekMinutes={weekMinutesByProject[project.id] ?? 0}
+          isShowingDetail={isShowingDetail}
+          onToggleDetail={toggleDetail}
           onAddEntry={onNavigateToAddEntry}
           onViewEntries={onNavigateToEntries}
           onTimerChange={refreshTimers}

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -1,7 +1,7 @@
 import { List } from "@raycast/api";
 import { useMemo, useState, useCallback } from "react";
 import { ProjectType } from "../types";
-import { buildWeekMinutesByProject } from "../utils";
+import { buildWeekMinutesByProject } from "../utils/project-utils";
 import {
   useProjects,
   useTimers,

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -19,12 +19,14 @@ type ProjectFilter = "active" | "archived" | "all";
 
 interface TimersViewProps {
   onNavigateToAddEntry: () => void;
+  onNavigateToAddEntryForProject: (project: ProjectType) => void;
   onNavigateToEntries: () => void;
   onNavigateToLogTimer: (project: ProjectType) => void;
 }
 
 export const TimersView = ({
   onNavigateToAddEntry,
+  onNavigateToAddEntryForProject,
   onNavigateToEntries,
   onNavigateToLogTimer,
 }: TimersViewProps) => {
@@ -99,7 +101,7 @@ export const TimersView = ({
           key={project.id}
           project={project}
           weekMinutes={weekMinutesByProject[project.id] ?? 0}
-          onAddEntry={onNavigateToLogTimer}
+          onAddEntry={onNavigateToAddEntryForProject}
           onViewEntries={onNavigateToEntries}
           onTimerChange={refreshTimers}
         />

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -1,32 +1,32 @@
 import { List } from "@raycast/api";
 import { useMemo, useState, useCallback } from "react";
 import { ProjectType } from "../types";
-import { buildWeekMinutesByProject } from "../utils/project-utils";
+import {
+  buildLatestUsedByProject,
+  buildWeekMinutesByProject,
+  sortProjectsByLatestUsed,
+} from "../utils/project-utils";
 import {
   useProjects,
   useTimers,
   useRecentEntries,
   useWeekEntries,
 } from "../hooks";
-import {
-  buildLatestUsedByProject,
-  sortProjectsByLatestUsed,
-} from "../utils/project-utils";
 import { TimerItem } from "../components/TimerItem";
 import { ProjectItem } from "../components/ProjectItem";
 
 type ProjectFilter = "active" | "archived" | "all";
 
 interface TimersViewProps {
-  onNavigateToAddEntryForProject: (project: ProjectType) => void;
-  onNavigateToEntries: () => void;
-  onNavigateToLogTimer: (project: ProjectType) => void;
+  onAddEntry: (project: ProjectType) => void;
+  onLogTimer: (project: ProjectType) => void;
+  onViewEntries: () => void;
 }
 
 export const TimersView = ({
-  onNavigateToAddEntryForProject,
-  onNavigateToEntries,
-  onNavigateToLogTimer,
+  onAddEntry,
+  onLogTimer,
+  onViewEntries,
 }: TimersViewProps) => {
   const [projectFilter, setProjectFilter] = useState<ProjectFilter>("active");
 
@@ -87,8 +87,8 @@ export const TimersView = ({
         <TimerItem
           key={timer.id}
           timer={timer}
-          onViewEntries={onNavigateToEntries}
-          onLogTimer={onNavigateToLogTimer}
+          onViewEntries={onViewEntries}
+          onLogTimer={onLogTimer}
           onTimerChange={refreshTimers}
         />
       ))}
@@ -98,8 +98,8 @@ export const TimersView = ({
           key={project.id}
           project={project}
           weekMinutes={weekMinutesByProject[project.id] ?? 0}
-          onAddEntry={onNavigateToAddEntryForProject}
-          onViewEntries={onNavigateToEntries}
+          onAddEntry={onAddEntry}
+          onViewEntries={onViewEntries}
           onTimerChange={refreshTimers}
         />
       ))}

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -18,14 +18,12 @@ import { ProjectItem } from "../components/ProjectItem";
 type ProjectFilter = "active" | "archived" | "all";
 
 interface TimersViewProps {
-  onNavigateToAddEntry: () => void;
   onNavigateToAddEntryForProject: (project: ProjectType) => void;
   onNavigateToEntries: () => void;
   onNavigateToLogTimer: (project: ProjectType) => void;
 }
 
 export const TimersView = ({
-  onNavigateToAddEntry,
   onNavigateToAddEntryForProject,
   onNavigateToEntries,
   onNavigateToLogTimer,
@@ -89,7 +87,6 @@ export const TimersView = ({
         <TimerItem
           key={timer.id}
           timer={timer}
-          onAddEntry={onNavigateToAddEntry}
           onViewEntries={onNavigateToEntries}
           onLogTimer={onNavigateToLogTimer}
           onTimerChange={refreshTimers}


### PR DESCRIPTION
## Summary

Reshapes the projects list and the Add Entry flow so every Add Entry path carries a project, and models that intent as a single discriminated union. The PR started as a project detail panel; based on iteration, the detail panel was dropped in favor of inline accessories plus a cleaner Add Entry architecture.

## Changes

### Project rows (TimersView)

- **This Week** time accessory on each project row (Clock icon + `hh:mm`), driven by `useWeekEntries`. Visible without toggling any detail mode.
- Entries-count tag and billable/unbillable Coins icon kept as accessories.
- Removed the project detail panel and the `useDetailToggle` wiring (the info that mattered is now on the row).

### Add Entry flow

Add Entry is now only reachable with a project context. Two distinct flows, both modeled as a discriminated `EntryDraft`:

```ts
type EntryDraft =
  | { mode: "manual";    project: ProjectType }   // ProjectItem -> Add Entry
  | { mode: "log-timer"; project: ProjectType };  // TimerItem  -> Log Timer
```

- **ProjectItem -> Add Entry (Cmd+Enter)**: preselects the highlighted project, default time, regular entry submit. No call to `GET /projects/:id/timer` (which previously 404'd as "Error: Not Found" when no timer was running).
- **TimerItem -> Log Timer**: preselects the timer's project, prefills elapsed time, posts via the log-timer endpoint.

Removed the unused project-less path: `handleAddEntry`, `TimersView.onNavigateToAddEntry`, `TimerItem.onAddEntry` + its action, `EntriesView.onAddEntry` + its action.

### Routing state

`timers.tsx` previously held four loosely-coupled state slots (`currentView`, `project`, `hasRunningTimer`, `editingEntry`). Collapsed into a single discriminated union so each screen owns its payload and invalid combinations are unrepresentable:

```ts
type Screen =
  | { name: "timers" }
  | { name: "entries" }
  | { name: "add-entry"; draft: EntryDraft }
  | { name: "edit-entry"; entry: EntryType };
```

### Renames / smaller cleanups

- Handlers in `timers.tsx`: verb-led intent names (`openManualEntry`, `openTimerLog`, `openEntries`, `openEditEntry`, `goToTimers`).
- `TimersView` props: `onAddEntry`, `onLogTimer`, `onViewEntries` (dropped the `NavigateTo` prefix).
- Dropped the unused `ViewType` export from `types.ts`.
- `AddEntryView` submit split into `submitTimerLog` / `submitEntry` branches; single `now` Date reused for elapsed-time calc.
- Consolidated `project-utils` imports in `TimersView`.
- Color row in the project list shows a colored swatch alongside the hex (still rendered on the row's project metadata where applicable).

## Manual verification checklist

- [ ] Project row shows This Week time when there is logged time, billable coin tint matches project billing.
- [ ] On a project with **no running timer**, Cmd+Enter opens Add Entry with that project preselected and the default time (no "Not Found" log).
- [ ] On a row with a **running/paused timer**, Log Timer opens Add Entry with that project preselected and the elapsed time prefilled.
- [ ] Changing the project in the form during a Log Timer flow discards the original timer and submits as a regular entry.
- [ ] Back (Cmd+[) from Add Entry returns to the timers list.

## Tests

`npm test`: 21 suites, 191 tests pass. tsc + `ray lint` clean.
