### PR TITLE
feat(projects): sort projects by most recently used

### DIFF
--- a/src/__tests__/sortProjectsByLatestUsed.test.ts
+++ b/src/__tests__/sortProjectsByLatestUsed.test.ts
@@ -64,12 +64,12 @@ describe("sort projects by latest used", () => {
     expect(sorted[1].id).toBe("p2");
   });
 
-  it("breaks ties alphabetically by name", () => {
+  it("preserves original order when dates are equal", () => {
     const projects = [makeProject("p1", "Zebra"), makeProject("p2", "Apple")];
     const latestUsed = buildLatestUsedByProject([]); // no entries, both have same ""
     const sorted = sortProjectsByLatestUsed(projects, latestUsed);
-    expect(sorted[0].name).toBe("Apple");
-    expect(sorted[1].name).toBe("Zebra");
+    expect(sorted[0].name).toBe("Zebra");
+    expect(sorted[1].name).toBe("Apple");
   });
 
   it("picks the most recent date when project has multiple entries", () => {

--- a/src/__tests__/sortProjectsByLatestUsed.test.ts
+++ b/src/__tests__/sortProjectsByLatestUsed.test.ts
@@ -1,0 +1,88 @@
+import { EntryType, ProjectType } from "../types";
+
+const makeProject = (id: string, name: string): ProjectType => ({
+  id,
+  name,
+  color: "#ff0000",
+  enabled: true,
+});
+
+const makeEntry = (projectId: string, date: string): Partial<EntryType> => ({
+  id: `${projectId}-${date}`,
+  date,
+  project: { id: projectId, name: "P", color: "#000", enabled: true },
+});
+
+// Mirrors latestUsedByProject computation in TimersView
+const buildLatestUsed = (
+  entries: Partial<EntryType>[],
+): Record<string, string> => {
+  const map: Record<string, string> = {};
+  for (const entry of entries) {
+    if (entry.project && entry.date) {
+      const current = map[entry.project.id];
+      if (!current || entry.date > current) {
+        map[entry.project.id] = entry.date;
+      }
+    }
+  }
+  return map;
+};
+
+// Mirrors sort logic in TimersView
+const sortProjects = (
+  projects: ProjectType[],
+  latestUsed: Record<string, string>,
+): ProjectType[] => {
+  return [...projects].sort((a, b) => {
+    const dateA = latestUsed[a.id] ?? "";
+    const dateB = latestUsed[b.id] ?? "";
+    if (dateA === dateB) return a.name.localeCompare(b.name);
+    return dateB.localeCompare(dateA);
+  });
+};
+
+describe("sort projects by latest used", () => {
+  it("returns projects ordered by most recent usage first", () => {
+    const projects = [
+      makeProject("p1", "Alpha"),
+      makeProject("p2", "Beta"),
+      makeProject("p3", "Gamma"),
+    ];
+    const entries = [
+      makeEntry("p1", "2026-05-10"),
+      makeEntry("p2", "2026-05-18"),
+      makeEntry("p3", "2026-05-15"),
+    ];
+    const latestUsed = buildLatestUsed(entries);
+    const sorted = sortProjects(projects, latestUsed);
+    expect(sorted.map((p) => p.id)).toEqual(["p2", "p3", "p1"]);
+  });
+
+  it("places projects with no entries at the end", () => {
+    const projects = [makeProject("p1", "Active"), makeProject("p2", "Unused")];
+    const entries = [makeEntry("p1", "2026-05-20")];
+    const latestUsed = buildLatestUsed(entries);
+    const sorted = sortProjects(projects, latestUsed);
+    expect(sorted[0].id).toBe("p1");
+    expect(sorted[1].id).toBe("p2");
+  });
+
+  it("breaks ties alphabetically by name", () => {
+    const projects = [makeProject("p1", "Zebra"), makeProject("p2", "Apple")];
+    const latestUsed = buildLatestUsed([]); // no entries, both have same ""
+    const sorted = sortProjects(projects, latestUsed);
+    expect(sorted[0].name).toBe("Apple");
+    expect(sorted[1].name).toBe("Zebra");
+  });
+
+  it("picks the most recent date when project has multiple entries", () => {
+    const entries = [
+      makeEntry("p1", "2026-05-01"),
+      makeEntry("p1", "2026-05-20"),
+      makeEntry("p1", "2026-05-10"),
+    ];
+    const latestUsed = buildLatestUsed(entries);
+    expect(latestUsed["p1"]).toBe("2026-05-20");
+  });
+});

--- a/src/__tests__/sortProjectsByLatestUsed.test.ts
+++ b/src/__tests__/sortProjectsByLatestUsed.test.ts
@@ -9,6 +9,7 @@ const makeProject = (id: string, name: string): ProjectType => ({
   name,
   color: "#ff0000",
   enabled: true,
+  billable: true,
 });
 
 const makeEntry = (projectId: string, date: string): EntryType => ({
@@ -28,7 +29,13 @@ const makeEntry = (projectId: string, date: string): EntryType => ({
     profile_image_url: "",
   },
   tags: [],
-  project: { id: projectId, name: "P", color: "#000", enabled: true },
+  project: {
+    id: projectId,
+    name: "P",
+    color: "#000",
+    enabled: true,
+    billable: true,
+  },
 });
 
 describe("sort projects by latest used", () => {

--- a/src/__tests__/sortProjectsByLatestUsed.test.ts
+++ b/src/__tests__/sortProjectsByLatestUsed.test.ts
@@ -1,4 +1,8 @@
 import { EntryType, ProjectType } from "../types";
+import {
+  buildLatestUsedByProject,
+  sortProjectsByLatestUsed,
+} from "../utils/project-utils";
 
 const makeProject = (id: string, name: string): ProjectType => ({
   id,
@@ -7,40 +11,25 @@ const makeProject = (id: string, name: string): ProjectType => ({
   enabled: true,
 });
 
-const makeEntry = (projectId: string, date: string): Partial<EntryType> => ({
+const makeEntry = (projectId: string, date: string): EntryType => ({
   id: `${projectId}-${date}`,
   date,
+  billable: true,
+  minutes: 60,
+  formatted_minutes: "1:00",
+  description: "",
+  approved_by: null,
+  approved_at: "",
+  user: {
+    id: "u1",
+    email: "user@example.com",
+    first_name: "Jane",
+    last_name: "Doe",
+    profile_image_url: "",
+  },
+  tags: [],
   project: { id: projectId, name: "P", color: "#000", enabled: true },
 });
-
-// Mirrors latestUsedByProject computation in TimersView
-const buildLatestUsed = (
-  entries: Partial<EntryType>[],
-): Record<string, string> => {
-  const map: Record<string, string> = {};
-  for (const entry of entries) {
-    if (entry.project && entry.date) {
-      const current = map[entry.project.id];
-      if (!current || entry.date > current) {
-        map[entry.project.id] = entry.date;
-      }
-    }
-  }
-  return map;
-};
-
-// Mirrors sort logic in TimersView
-const sortProjects = (
-  projects: ProjectType[],
-  latestUsed: Record<string, string>,
-): ProjectType[] => {
-  return [...projects].sort((a, b) => {
-    const dateA = latestUsed[a.id] ?? "";
-    const dateB = latestUsed[b.id] ?? "";
-    if (dateA === dateB) return a.name.localeCompare(b.name);
-    return dateB.localeCompare(dateA);
-  });
-};
 
 describe("sort projects by latest used", () => {
   it("returns projects ordered by most recent usage first", () => {
@@ -54,24 +43,24 @@ describe("sort projects by latest used", () => {
       makeEntry("p2", "2026-05-18"),
       makeEntry("p3", "2026-05-15"),
     ];
-    const latestUsed = buildLatestUsed(entries);
-    const sorted = sortProjects(projects, latestUsed);
+    const latestUsed = buildLatestUsedByProject(entries);
+    const sorted = sortProjectsByLatestUsed(projects, latestUsed);
     expect(sorted.map((p) => p.id)).toEqual(["p2", "p3", "p1"]);
   });
 
   it("places projects with no entries at the end", () => {
     const projects = [makeProject("p1", "Active"), makeProject("p2", "Unused")];
     const entries = [makeEntry("p1", "2026-05-20")];
-    const latestUsed = buildLatestUsed(entries);
-    const sorted = sortProjects(projects, latestUsed);
+    const latestUsed = buildLatestUsedByProject(entries);
+    const sorted = sortProjectsByLatestUsed(projects, latestUsed);
     expect(sorted[0].id).toBe("p1");
     expect(sorted[1].id).toBe("p2");
   });
 
   it("breaks ties alphabetically by name", () => {
     const projects = [makeProject("p1", "Zebra"), makeProject("p2", "Apple")];
-    const latestUsed = buildLatestUsed([]); // no entries, both have same ""
-    const sorted = sortProjects(projects, latestUsed);
+    const latestUsed = buildLatestUsedByProject([]); // no entries, both have same ""
+    const sorted = sortProjectsByLatestUsed(projects, latestUsed);
     expect(sorted[0].name).toBe("Apple");
     expect(sorted[1].name).toBe("Zebra");
   });
@@ -82,7 +71,7 @@ describe("sort projects by latest used", () => {
       makeEntry("p1", "2026-05-20"),
       makeEntry("p1", "2026-05-10"),
     ];
-    const latestUsed = buildLatestUsed(entries);
+    const latestUsed = buildLatestUsedByProject(entries);
     expect(latestUsed["p1"]).toBe("2026-05-20");
   });
 });

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -1,6 +1,7 @@
 // Optimized hooks
 import {
   useWeekEntries,
+  useRecentEntries,
   useApiData,
   useTimers,
   useProjects,
@@ -22,6 +23,7 @@ export {
   useTags,
   useEntriesApi,
   useWeekEntries,
+  useRecentEntries,
   useEntries,
   // Action hooks
   useTimerActions,

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -83,6 +83,19 @@ export const useTimer = (projectId: string | null) => {
   });
 };
 
+export const useRecentEntries = (days = 30) => {
+  const fromDate = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - days);
+    return dateOnTimezone(d);
+  }, [days]);
+
+  const today = useMemo(() => dateOnTimezone(new Date()), []);
+
+  const endpoint = `/current_user/entries?from=${fromDate}&to=${today}&per_page=100`;
+  return useApiData<EntryType[]>(endpoint);
+};
+
 export const useWeekEntries = () => {
   const sunday = useMemo(() => {
     const today = new Date();

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -5,3 +5,4 @@ export * from "./user-utils";
 export * from "./toast-utils";
 export * from "./description-utils";
 export * from "./timer-utils";
+export * from "./project-utils";

--- a/src/utils/project-utils.ts
+++ b/src/utils/project-utils.ts
@@ -22,7 +22,6 @@ export const sortProjectsByLatestUsed = (
   return [...projects].sort((a, b) => {
     const dateA = latestUsed[a.id] ?? "";
     const dateB = latestUsed[b.id] ?? "";
-    if (dateA === dateB) return a.name.localeCompare(b.name);
     return dateB.localeCompare(dateA);
   });
 };

--- a/src/utils/project-utils.ts
+++ b/src/utils/project-utils.ts
@@ -1,0 +1,28 @@
+import { EntryType, ProjectType } from "../types";
+
+export const buildLatestUsedByProject = (
+  entries: EntryType[],
+): Record<string, string> => {
+  const map: Record<string, string> = {};
+  for (const entry of entries) {
+    if (entry.project) {
+      const current = map[entry.project.id];
+      if (!current || entry.date > current) {
+        map[entry.project.id] = entry.date;
+      }
+    }
+  }
+  return map;
+};
+
+export const sortProjectsByLatestUsed = (
+  projects: ProjectType[],
+  latestUsed: Record<string, string>,
+): ProjectType[] => {
+  return [...projects].sort((a, b) => {
+    const dateA = latestUsed[a.id] ?? "";
+    const dateB = latestUsed[b.id] ?? "";
+    if (dateA === dateB) return a.name.localeCompare(b.name);
+    return dateB.localeCompare(dateA);
+  });
+};

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -21,7 +21,8 @@ export const TimersView = ({
   onNavigateToLogTimer,
 }: TimersViewProps) => {
   const { data: projects = [], isLoading: projectsLoading } = useProjects();
-  const { data: recentEntries = [] } = useRecentEntries(30);
+  const { data: recentEntries = [], isLoading: recentEntriesLoading } =
+    useRecentEntries(30);
 
   const {
     data: timers = [],
@@ -29,7 +30,7 @@ export const TimersView = ({
     mutate: refreshTimers,
   } = useTimers();
 
-  const isLoading = projectsLoading || timersLoading;
+  const isLoading = projectsLoading || timersLoading || recentEntriesLoading;
 
   const latestUsedByProject = useMemo(
     () => buildLatestUsedByProject(recentEntries),

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -2,7 +2,10 @@ import { List } from "@raycast/api";
 import { useMemo } from "react";
 import { ProjectType } from "../types";
 import { useProjects, useTimers, useRecentEntries } from "../hooks";
-import { buildLatestUsedByProject, sortProjectsByLatestUsed } from "../utils";
+import {
+  buildLatestUsedByProject,
+  sortProjectsByLatestUsed,
+} from "../utils/project-utils";
 import { TimerItem } from "../components/TimerItem";
 import { ProjectItem } from "../components/ProjectItem";
 

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -2,6 +2,7 @@ import { List } from "@raycast/api";
 import { useMemo } from "react";
 import { ProjectType } from "../types";
 import { useProjects, useTimers, useRecentEntries } from "../hooks";
+import { buildLatestUsedByProject, sortProjectsByLatestUsed } from "../utils";
 import { TimerItem } from "../components/TimerItem";
 import { ProjectItem } from "../components/ProjectItem";
 
@@ -27,16 +28,10 @@ export const TimersView = ({
 
   const isLoading = projectsLoading || timersLoading;
 
-  const latestUsedByProject = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const entry of recentEntries) {
-      const current = map[entry.project.id];
-      if (!current || entry.date > current) {
-        map[entry.project.id] = entry.date;
-      }
-    }
-    return map;
-  }, [recentEntries]);
+  const latestUsedByProject = useMemo(
+    () => buildLatestUsedByProject(recentEntries),
+    [recentEntries],
+  );
 
   const projectsWithoutTimers = useMemo(() => {
     const projectIdsWithTimers = new Set(
@@ -45,12 +40,7 @@ export const TimersView = ({
     const filtered = projects.filter(
       (project) => !projectIdsWithTimers.has(project.id),
     );
-    return [...filtered].sort((a, b) => {
-      const dateA = latestUsedByProject[a.id] ?? "";
-      const dateB = latestUsedByProject[b.id] ?? "";
-      if (dateA === dateB) return a.name.localeCompare(b.name);
-      return dateB.localeCompare(dateA);
-    });
+    return sortProjectsByLatestUsed(filtered, latestUsedByProject);
   }, [projects, timers, latestUsedByProject]);
 
   return (

--- a/src/views/TimersView.tsx
+++ b/src/views/TimersView.tsx
@@ -1,7 +1,7 @@
 import { List } from "@raycast/api";
 import { useMemo } from "react";
 import { ProjectType } from "../types";
-import { useProjects, useTimers } from "../hooks";
+import { useProjects, useTimers, useRecentEntries } from "../hooks";
 import { TimerItem } from "../components/TimerItem";
 import { ProjectItem } from "../components/ProjectItem";
 
@@ -17,6 +17,7 @@ export const TimersView = ({
   onNavigateToLogTimer,
 }: TimersViewProps) => {
   const { data: projects = [], isLoading: projectsLoading } = useProjects();
+  const { data: recentEntries = [] } = useRecentEntries(30);
 
   const {
     data: timers = [],
@@ -26,12 +27,31 @@ export const TimersView = ({
 
   const isLoading = projectsLoading || timersLoading;
 
+  const latestUsedByProject = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const entry of recentEntries) {
+      const current = map[entry.project.id];
+      if (!current || entry.date > current) {
+        map[entry.project.id] = entry.date;
+      }
+    }
+    return map;
+  }, [recentEntries]);
+
   const projectsWithoutTimers = useMemo(() => {
     const projectIdsWithTimers = new Set(
       timers.map((timer) => timer.project.id),
     );
-    return projects.filter((project) => !projectIdsWithTimers.has(project.id));
-  }, [projects, timers]);
+    const filtered = projects.filter(
+      (project) => !projectIdsWithTimers.has(project.id),
+    );
+    return [...filtered].sort((a, b) => {
+      const dateA = latestUsedByProject[a.id] ?? "";
+      const dateB = latestUsedByProject[b.id] ?? "";
+      if (dateA === dateB) return a.name.localeCompare(b.name);
+      return dateB.localeCompare(dateA);
+    });
+  }, [projects, timers, latestUsedByProject]);
 
   return (
     <List isLoading={isLoading}>


### PR DESCRIPTION
## Summary

- Projects without active timers are now sorted by most-recently-used date
- Derived from `GET /current_user/entries` over the last 30 days — no new API endpoint
- Projects with no recent entries fall to the bottom, sorted alphabetically among themselves

## Changes

- `useApiData.ts`: new `useRecentEntries(days)` hook
- `hooks/index.tsx`: exports `useRecentEntries`
- `TimersView.tsx`: builds a `latestUsedByProject` map and uses it to sort `projectsWithoutTimers`

## Test plan

- [ ] Open the timers/projects view — projects you recently tracked time for appear first
- [ ] Projects with no activity in last 30 days appear at the bottom
- [ ] Projects with equal recency are sorted alphabetically
- [ ] Unit tests in `sortProjectsByLatestUsed.test.ts` cover ordering, tie-breaking, and edge cases