### PR TITLE
chore: remove all leftover pnpm references after yarn migration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,19 +33,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
+          cache: "yarn"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: yarn install --frozen-lockfile
 
       - name: Build extension
-        run: pnpm run build
+        run: yarn build
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,21 +6,21 @@ This file contains development guidelines for agentic coding assistants working 
 
 ```bash
 # Development
-pnpm run dev           # Start Raycast development mode
-pnpm run build         # Build extension for production
+yarn dev               # Start Raycast development mode
+yarn build             # Build extension for production
 
 # Linting & Formatting
-pnpm run lint          # Run ESLint
-pnpm run fix-lint      # Auto-fix linting issues
+yarn lint              # Run ESLint
+yarn fix-lint          # Auto-fix linting issues
 
 # Testing
-pnpm test              # Run all tests
-pnpm run test:watch    # Run tests in watch mode
-pnpm run test:coverage # Run tests with coverage report
+yarn test              # Run all tests
+yarn test:watch        # Run tests in watch mode
+yarn test:coverage     # Run tests with coverage report
 
 # Single Test Execution
-pnpm test -- useApiData.test.ts           # Run specific test file
-pnpm test -- -t "should fetch timers"     # Run tests matching pattern
+yarn test useApiData.test.ts              # Run specific test file
+yarn test -- -t "should fetch timers"    # Run tests matching pattern
 ```
 
 ## TypeScript Configuration

--- a/docs/API.md
+++ b/docs/API.md
@@ -232,10 +232,10 @@ The Noko API has rate limits that the extension respects:
 
 ```bash
 # Test API connectivity
-pnpm run test:api
+yarn test:api
 
 # Test specific endpoints
-pnpm run test:endpoints
+yarn test:endpoints
 ```
 
 ### Manual Testing

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -31,7 +31,7 @@ git remote add upstream https://github.com/JuanVqz/noko-for-raycast.git
 ### 2. Install Dependencies
 
 ```bash
-pnpm install
+yarn install
 ```
 
 ### 3. Set Up Development Environment
@@ -111,16 +111,16 @@ src/
 
 ```bash
 # Run linting
-pnpm run lint
+yarn lint
 
 # Fix linting issues
-pnpm run fix-lint
+yarn fix-lint
 
 # Run tests
-pnpm test
+yarn test
 
 # Run tests with coverage
-pnpm run test:coverage
+yarn test:coverage
 ```
 
 ## 📝 Pull Request Process
@@ -133,9 +133,9 @@ pnpm run test:coverage
    - Verify no regressions
 
 2. **Code Quality**
-   - Run `pnpm run lint` and fix any issues
-   - Run `pnpm run fix-lint` to auto-fix issues
-   - Run `pnpm test` to ensure tests pass
+   - Run `yarn lint` and fix any issues
+   - Run `yarn fix-lint` to auto-fix issues
+   - Run `yarn test` to ensure tests pass
 
 3. **Documentation**
    - Update documentation if needed

--- a/docs/CONVENTIONAL_COMMITS.md
+++ b/docs/CONVENTIONAL_COMMITS.md
@@ -8,10 +8,10 @@ This guide helps you write proper conventional commit messages that work with Re
 
 ```bash
 # Install dependencies first
-pnpm install
+yarn install
 
 # Use interactive commit tool
-pnpm run commit
+yarn commit
 ```
 
 This will guide you through creating a proper conventional commit message step by step.
@@ -109,7 +109,7 @@ The `onStart` prop is now `onTimerStart`.
 ### 1. **Commitizen** (Interactive)
 
 ```bash
-pnpm run commit
+yarn commit
 ```
 
 This will ask you:
@@ -132,7 +132,7 @@ You can add a pre-commit hook to enforce conventional commits:
 
 ```bash
 # Install commitlint
-pnpm add -D @commitlint/cli @commitlint/config-conventional
+yarn add -D @commitlint/cli @commitlint/config-conventional
 
 # Create .commitlintrc.js
 echo "module.exports = {extends: ['@commitlint/config-conventional']}" > .commitlintrc.js
@@ -285,7 +285,7 @@ feat: add timer pause functionality
 git add .
 
 # Use commitizen for proper format
-pnpm run commit
+yarn commit
 
 # Push changes
 git push origin main

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -30,7 +30,7 @@ This guide helps you resolve common issues with the Noko Raycast extension.
 
    ```bash
    # Check for build errors
-   pnpm run dev
+   yarn dev
    # Look for compilation errors in terminal
    ```
 
@@ -163,8 +163,8 @@ This guide helps you resolve common issues with the Noko Raycast extension.
 4. **Update Dependencies**
    ```bash
    # Update to latest versions
-   pnpm update
-   pnpm run build
+   yarn upgrade
+   yarn build
    ```
 
 ## 🔧 Debug Mode
@@ -244,26 +244,26 @@ This guide helps you resolve common issues with the Noko Raycast extension.
 
    ```bash
    # Check TypeScript errors
-   pnpm exec tsc --noEmit
+   yarn tsc --noEmit
 
    # Check linting issues
-   pnpm run lint
+   yarn lint
 
    # Format code
-   pnpm run format
+   yarn format
    ```
 
 2. **Dependency Issues**
 
    ```bash
    # Clear node_modules and reinstall
-   rm -rf node_modules package-lock.json pnpm-lock.yaml
-   pnpm install
+   rm -rf node_modules package-lock.json yarn.lock
+   yarn install
    ```
 
 3. **Environment Issues**
    - Check Node.js version
-   - Verify pnpm version
+   - Verify yarn version
    - Check environment variables
 
 ## 📞 Getting Help
@@ -342,21 +342,21 @@ raycast --version
 # Check Node.js version
 node --version
 
-# Check pnpm version
-pnpm --version
+# Check yarn version
+yarn --version
 ```
 
 ### Extension Information
 
 ```bash
 # Check extension build
-pnpm run build
+yarn build
 
 # Check for TypeScript errors
-pnpm exec tsc --noEmit
+yarn tsc --noEmit
 
 # Check linting
-pnpm run lint
+yarn lint
 ```
 
 ### Network Diagnostics

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ Before you begin, ensure you have the following installed:
 
 - **macOS** 10.15+ (Catalina or later)
 - **Node.js** 16.0 or higher
-- **pnpm** (fast, disk space efficient package manager)
+- yarn (fast, disk space efficient package manager)
 - **Raycast** (latest version)
 - **Git** (for version control)
 
@@ -24,7 +24,7 @@ cd noko-for-raycast
 ### 2. Install Dependencies
 
 ```bash
-pnpm install
+yarn install
 ```
 
 ### 3. Configure Raycast Development
@@ -66,7 +66,7 @@ pnpm install
 ### 5. Start Development Server
 
 ```bash
-pnpm run dev
+yarn dev
 ```
 
 This will:
@@ -143,45 +143,45 @@ noko-for-raycast/
 #### Run Prettier (Code Formatting)
 
 ```bash
-pnpm exec prettier --write .
+yarn prettier --write .
 ```
 
 #### Run TypeScript Check
 
 ```bash
-pnpm exec tsc --noEmit
+yarn tsc --noEmit
 ```
 
 #### Run Linter
 
 ```bash
 # Check for linting issues
-pnpm run lint
+yarn lint
 ```
 
 ## 🔧 Available Scripts
 
 ```bash
 # Start development server
-pnpm run dev
+yarn dev
 
 # Build for production
-pnpm run build
+yarn build
 
 # Lint code
-pnpm run lint
+yarn lint
 
 # Fix linting issues
-pnpm run fix-lint
+yarn fix-lint
 
 # Run tests
-pnpm test
+yarn test
 
 # Run tests in watch mode
-pnpm run test:watch
+yarn test:watch
 
 # Run tests with coverage
-pnpm run test:coverage
+yarn test:coverage
 ```
 
 ## 🐛 Debugging
@@ -199,7 +199,7 @@ pnpm run test:coverage
    - Ensure your token has proper permissions
 
 3. **Build Errors**
-   - Run `pnpm install` to ensure dependencies are installed
+   - Run `yarn install` to ensure dependencies are installed
    - Check TypeScript errors with `npx tsc --noEmit`
    - Verify all imports are correct
 
@@ -219,7 +219,7 @@ pnpm run test:coverage
 
 ```bash
 # Build the extension
-pnpm run build
+yarn build
 
 # The built extension will be in the dist/ folder
 ```
@@ -231,9 +231,9 @@ pnpm run build
 1. **Prepare for Release**
 
    ```bash
-   pnpm run build
-   pnpm run lint
-   pnpm test
+   yarn build
+   yarn lint
+   yarn test
    ```
 
 2. **Create Release**

--- a/scripts/raycast-lint.sh
+++ b/scripts/raycast-lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# ray lint enforces npm-only lockfiles and rejects pnpm-lock.yaml.
+# ray lint enforces npm-only lockfiles and rejects yarn.lock.
 # Run ESLint and Prettier directly instead.
 if [[ "${1:-}" == "--fix" ]]; then
   yarn eslint src/ --fix


### PR DESCRIPTION
## Summary

Cleans up pnpm references left behind after #87 migrated to yarn.

**Critical fix:** `release-please.yml` was still installing and running pnpm, which would break release builds. Now uses yarn + node 24 to match CI.

**Other changes:**
- `AGENTS.md` commands updated to yarn
- `scripts/raycast-lint.sh` comment updated
- All docs updated (CONTRIBUTING, development, TROUBLESHOOTING, API, CONVENTIONAL_COMMITS)