### PR TITLE
fix(entries): paginate entry fetches and show entry log time

### DIFF
--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -1,7 +1,7 @@
 import { Icon, List, ActionPanel, Action, confirmAlert } from "@raycast/api";
 import { memo, useMemo, useCallback } from "react";
 import { EntryType } from "../types";
-import { userName, formatTags } from "../utils";
+import { userName, formatTags, formattedCreatedTime } from "../utils";
 import { useEntryActions } from "../hooks";
 import { SUMMARY_COLORS } from "../constants";
 
@@ -68,6 +68,15 @@ export const EntryItem = memo<EntryItemProps>(
               <List.Item.Detail.Metadata.Separator />
             </>
           )}
+          {entry.created_at && formattedCreatedTime(entry.created_at) && (
+            <>
+              <List.Item.Detail.Metadata.Label
+                title="Logged At"
+                text={formattedCreatedTime(entry.created_at)}
+              />
+              <List.Item.Detail.Metadata.Separator />
+            </>
+          )}
           {entry.project && (
             <>
               <List.Item.Detail.Metadata.Label
@@ -126,6 +135,15 @@ export const EntryItem = memo<EntryItemProps>(
           tintColor: entry.project.color,
         }}
         accessories={[
+          ...(entry.created_at && formattedCreatedTime(entry.created_at)
+            ? [
+                {
+                  icon: Icon.Clock,
+                  text: formattedCreatedTime(entry.created_at),
+                  tooltip: `Logged at ${formattedCreatedTime(entry.created_at)}`,
+                },
+              ]
+            : []),
           ...(entry.approved_by
             ? [
                 {

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -78,7 +78,7 @@ export const useTags = () => {
 };
 
 export const useEntries = (dateFilter: string) => {
-  const endpoint = `/current_user/entries?from=${dateFilter}&to=${dateFilter}`;
+  const endpoint = `/current_user/entries?from=${dateFilter}&to=${dateFilter}&per_page=1000`;
   return useApiData<EntryType[]>(endpoint, {
     enabled: !!dateFilter,
   });
@@ -114,6 +114,6 @@ export const useWeekEntries = () => {
 
   const today = useMemo(() => dateOnTimezone(new Date()), []);
 
-  const endpoint = `/current_user/entries?from=${sunday}&to=${today}`;
+  const endpoint = `/current_user/entries?from=${sunday}&to=${today}&per_page=1000`;
   return useApiData<EntryType[]>(endpoint);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ type ProjectType = {
 type EntryType = {
   id: string;
   date: string;
+  created_at?: string;
   billable: boolean;
   minutes: number;
   formatted_minutes: string;

--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -14,6 +14,27 @@ export const dateOnTimezone = (date: Date): string => {
   return formatter.format(date);
 };
 
+export const formattedCreatedTime = (createdAt: string): string => {
+  if (!createdAt) {
+    return "";
+  }
+
+  const date = new Date(createdAt);
+  if (isNaN(date.getTime())) {
+    return "";
+  }
+
+  const { timezone } = getPreferenceValues<IPreferences>();
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return formatter.format(date);
+};
+
 export const formattedFilterDate = (filter: EntryDateEnum): string => {
   const today = new Date();
 


### PR DESCRIPTION
## Summary

Fixes the week summary undercounting logged hours and adds the creation time to entries.

### Week summary pagination bug

The Noko v2 API paginates entries at 30 per page by default, and `useFetch` does not follow the `Link` header. The week-summary fetch sent no `per_page`, so any week with more than 30 entries dropped the remainder. The plugin showed ~30h against 38.5h on the Noko website.

Added `per_page=1000` (Noko's max) to the week and daily entry endpoints so every entry in range is summed.

### Entry log time

Each entry now shows its `created_at` time as a clock accessory and a "Logged At" detail row. This makes repeated entries on the same project distinguishable and confirms a save worked.

## Testing

- `yarn jest` — 210 passing
- `npx tsc --noEmit` — clean
- `yarn build` — success
- Verified in Raycast dev: week total now matches the website
