### PR TITLE
fix(entries): use full week window for week summary

### DIFF
--- a/src/__tests__/useWeekEntries.test.ts
+++ b/src/__tests__/useWeekEntries.test.ts
@@ -37,7 +37,7 @@ describe("useWeekEntries", () => {
     jest.useRealTimers();
   });
 
-  it("should fetch entries from Sunday to today (Wednesday)", () => {
+  it("should fetch entries for the full week (Sunday to Saturday)", () => {
     const mockEntries: EntryType[] = [
       {
         id: "1",
@@ -70,11 +70,31 @@ describe("useWeekEntries", () => {
 
     expect(mockUseFetch).toHaveBeenCalledWith(
       expect.stringContaining(
-        "/current_user/entries?from=2024-01-07&to=2024-01-10",
+        "/current_user/entries?from=2024-01-07&to=2024-01-13",
       ),
       expect.objectContaining({
         headers: expect.any(Object),
       }),
+    );
+  });
+
+  it("should include entries logged for future days in the same week", () => {
+    // Wednesday 2024-01-10: the window must still reach Saturday 2024-01-13
+    // so an entry logged for tomorrow (or later this week) is counted.
+    mockUseFetch.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+      pagination: undefined,
+    });
+
+    renderHook(() => useWeekEntries());
+
+    expect(mockUseFetch).toHaveBeenCalledWith(
+      expect.stringContaining("from=2024-01-07&to=2024-01-13"),
+      expect.any(Object),
     );
   });
 
@@ -93,7 +113,7 @@ describe("useWeekEntries", () => {
     renderHook(() => useWeekEntries());
 
     expect(mockUseFetch).toHaveBeenCalledWith(
-      expect.stringContaining("from=2024-01-07&to=2024-01-08"),
+      expect.stringContaining("from=2024-01-07&to=2024-01-13"),
       expect.any(Object),
     );
   });
@@ -113,7 +133,27 @@ describe("useWeekEntries", () => {
     renderHook(() => useWeekEntries());
 
     expect(mockUseFetch).toHaveBeenCalledWith(
-      expect.stringContaining("from=2024-01-14&to=2024-01-14"),
+      expect.stringContaining("from=2024-01-14&to=2024-01-20"),
+      expect.any(Object),
+    );
+  });
+
+  it("should handle Saturday (end of week equals today)", () => {
+    jest.setSystemTime(new Date("2024-01-13T12:00:00Z"));
+
+    mockUseFetch.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+      mutate: jest.fn(),
+      revalidate: jest.fn(),
+      pagination: undefined,
+    });
+
+    renderHook(() => useWeekEntries());
+
+    expect(mockUseFetch).toHaveBeenCalledWith(
+      expect.stringContaining("from=2024-01-07&to=2024-01-13"),
       expect.any(Object),
     );
   });

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -112,8 +112,13 @@ export const useWeekEntries = () => {
     return dateOnTimezone(sundayDate);
   }, []);
 
-  const today = useMemo(() => dateOnTimezone(new Date()), []);
+  const saturday = useMemo(() => {
+    const today = new Date();
+    const saturdayDate = new Date(today);
+    saturdayDate.setDate(today.getDate() - today.getDay() + 6);
+    return dateOnTimezone(saturdayDate);
+  }, []);
 
-  const endpoint = `/current_user/entries?from=${sunday}&to=${today}&per_page=1000`;
+  const endpoint = `/current_user/entries?from=${sunday}&to=${saturday}&per_page=1000`;
   return useApiData<EntryType[]>(endpoint);
 };


### PR DESCRIPTION
## Problem

The week summary undercounts hours. Saving a record for a future day in the current week (e.g. tomorrow) is not reflected: Noko reports 28h while the plugin reports 25:30h.

Root cause: `useWeekEntries` fetched entries from start-of-week (Sunday) to **today**, instead of the full week window. Entries logged for days later in the same week were excluded.

## Fix

Compute the window end as **Saturday** (Sunday + 6) so the full Sunday-to-Saturday week is fetched.

```diff
- const endpoint = `/current_user/entries?from=${sunday}&to=${today}&per_page=1000`;
+ const endpoint = `/current_user/entries?from=${sunday}&to=${saturday}&per_page=1000`;
```

## Tests

- Updated `useWeekEntries` tests to assert the full Sunday-to-Saturday window.
- Added coverage for entries logged for future days in the same week.
- Added a Saturday edge case (end of week equals today).

All 212 tests pass.
