### PR TITLE
fix(entries): show lock icon before log time in entry list

### DIFF
--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -154,3 +154,32 @@ describe("EntryItem approved/locked indicator", () => {
     expect(wouldNavigate).toBe(true);
   });
 });
+
+// Mirrors the accessories array order in EntryItem: lock → clock → coins
+const buildAccessories = (entry: EntryType): string[] => {
+  const accessories: string[] = [];
+  if (entry.approved_by) accessories.push("lock");
+  if (entry.created_at) accessories.push("clock");
+  accessories.push("coins");
+  return accessories;
+};
+
+describe("EntryItem accessory order", () => {
+  it("lock appears before clock for approved entries", () => {
+    const entry = makeEntry({ approved_by: makeApprovedBy(), created_at: "2026-06-17T10:00:00Z" });
+    const order = buildAccessories(entry);
+    expect(order.indexOf("lock")).toBeLessThan(order.indexOf("clock"));
+  });
+
+  it("lock appears before coins for approved entries", () => {
+    const entry = makeEntry({ approved_by: makeApprovedBy() });
+    const order = buildAccessories(entry);
+    expect(order.indexOf("lock")).toBeLessThan(order.indexOf("coins"));
+  });
+
+  it("no lock accessory for unapproved entries", () => {
+    const entry = makeEntry({ approved_by: null });
+    const order = buildAccessories(entry);
+    expect(order).not.toContain("lock");
+  });
+});

--- a/src/__tests__/EntryItem.test.ts
+++ b/src/__tests__/EntryItem.test.ts
@@ -166,7 +166,10 @@ const buildAccessories = (entry: EntryType): string[] => {
 
 describe("EntryItem accessory order", () => {
   it("lock appears before clock for approved entries", () => {
-    const entry = makeEntry({ approved_by: makeApprovedBy(), created_at: "2026-06-17T10:00:00Z" });
+    const entry = makeEntry({
+      approved_by: makeApprovedBy(),
+      created_at: "2026-06-17T10:00:00Z",
+    });
     const order = buildAccessories(entry);
     expect(order.indexOf("lock")).toBeLessThan(order.indexOf("clock"));
   });

--- a/src/components/EntryItem.tsx
+++ b/src/components/EntryItem.tsx
@@ -135,20 +135,20 @@ export const EntryItem = memo<EntryItemProps>(
           tintColor: entry.project.color,
         }}
         accessories={[
+          ...(entry.approved_by
+            ? [
+                {
+                  icon: Icon.Lock,
+                  tooltip: `Approved by ${entry.approved_by.first_name} ${entry.approved_by.last_name}`,
+                },
+              ]
+            : []),
           ...(entry.created_at && formattedCreatedTime(entry.created_at)
             ? [
                 {
                   icon: Icon.Clock,
                   text: formattedCreatedTime(entry.created_at),
                   tooltip: `Logged at ${formattedCreatedTime(entry.created_at)}`,
-                },
-              ]
-            : []),
-          ...(entry.approved_by
-            ? [
-                {
-                  icon: Icon.Lock,
-                  tooltip: `Approved by ${entry.approved_by.first_name} ${entry.approved_by.last_name}`,
                 },
               ]
             : []),


### PR DESCRIPTION
## Summary

- Move the lock icon accessory before the clock/time accessory in `EntryItem`
- Fixes broken UI layout where the lock appeared after the log time on approved/paid entries

## Test plan

- [ ] Log an entry that is approved/locked
- [ ] Open today's entries list in Raycast
- [ ] Confirm lock icon appears before the clock time, not after