### PR TITLE
chore(deps): batch dependabot updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint": "^9.39.4",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-test-renderer": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "25.9.2",
+    "@types/node": "25.9.3",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/react-test-renderer": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^30.0.0",
     "@types/node": "25.9.2",
-    "@types/react": "^19.2.16",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/react-test-renderer": "^19.1.0",
     "eslint": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   ],
   "dependencies": {
     "@raycast/api": "^1.104.19",
-    "@raycast/utils": "^2.2.5"
+    "@raycast/utils": "^2.2.6"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3316,10 +3316,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
-  integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
+prettier@^3.8.4:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.4.tgz#f334f013ac04a96676f24dabc23c1c4ae1bae411"
+  integrity sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==
 
 pretty-format@30.4.1, pretty-format@^30.0.0:
   version "30.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,10 +1242,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@*", "@types/node@25.9.2":
-  version "25.9.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.2.tgz#fc8958e757994b71fee516f9634bdb03d1b19e9f"
-  integrity sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==
+"@types/node@*", "@types/node@25.9.3":
+  version "25.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.9.3.tgz#11dfe7a33e68fa5c560f0aa76cc5595621ef26b9"
+  integrity sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,10 +1104,10 @@
   dependencies:
     "@typescript-eslint/utils" "^8.26.1"
 
-"@raycast/utils@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@raycast/utils/-/utils-2.2.5.tgz#3ebc76d5ef2e74723d3c4e417b1a2a2a8b16e6a9"
-  integrity sha512-1o6zGRECh1KNe6CBx68iMPOrNYbV56opqs4zUtDr6Wmq4F7Ww3d8uLTXKVzXlGyJmpAys/Eliw6cKIP7dPdFfw==
+"@raycast/utils@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@raycast/utils/-/utils-2.2.6.tgz#c2fe526dc6d2eebca1944670176be6b903fbc557"
+  integrity sha512-/6NUftsaNjboTOhTiadRhQ+hgfsg9AxKdYCpGGbwfUghTX9M+ljbGBesCxQ+X5GBIBM+9lH3ma7GMwZPSPzJgw==
   dependencies:
     dequal "^2.0.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,10 +1268,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^19.2.16":
-  version "19.2.16"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.16.tgz#9868b153fd9e34e0117afcd5d7e372b8179337e1"
-  integrity sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==
+"@types/react@*", "@types/react@^19.2.17":
+  version "19.2.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.17.tgz#dccac365baa0f1734ec270ff4b51c89465e8dc7f"
+  integrity sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==
   dependencies:
     csstype "^3.2.2"
 


### PR DESCRIPTION
## Summary

Combines 4 open dependabot PRs into one for easier review and merge:

- #119 prettier 3.8.3 → 3.8.4 (linting-dependencies)
- #118 @types/node 25.9.2 → 25.9.3 (typescript-dependencies)
- #115 @types/react 19.2.16 → 19.2.17 (react-dependencies)
- #114 @raycast/utils 2.2.5 → 2.2.6 (raycast-dependencies)

All are minor/patch bumps. Tests pass (215/215).

## Test plan

- [ ] All 215 tests pass (verified locally)
- [ ] Build succeeds with `yarn build`
- [ ] Spot-check that the Raycast extension loads without errors after merge